### PR TITLE
Fix id_of_string to handle special characters as described.

### DIFF
--- a/opam
+++ b/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer: "philippe.wang@gmail.com"
+authors: [ "Philippe Wang <philippe.wang@gmail.com>" ]
+license: "ISC"
+homepage: "https://github.com/ocaml/omd"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: [
+  ["ocamlfind" "remove" "omd"]
+]
+depends: [
+  "base-bigarray"
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
+tags: [
+  "org:ocamllabs"
+  "org:mirage"
+]


### PR DESCRIPTION
`id_of_string`, which is used to come up with the `id` attributes for headers in the HTML backend, does not handle non-alphanumeric characters as its comments describe.
I've written a replacement that does what I think `id_of_string` is intended to do, and made a file with some example cases for comparison.

```ocaml
let old_id_of_string s =
  let l = String.length s in
  let gen_id s =
    let b = Buffer.create l in
    let rec loop i flag flag2 =
      (* [flag] prevents trailing dashes;
         [flag2] prevents IDs from starting with dashes *)
      if i = l then
        ()
      else
        match s.[i] with
        | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' as c ->
          (if not (flag2 || flag) then Buffer.add_char b '-');
          Buffer.add_char b c;
          loop (i+1) true true
        | _ ->
          if flag2 || flag then
            loop (i+1) false flag2
          else
            (Buffer.add_char b '-';
             loop (i+1) true flag2)
    in
    loop 0 true true;
    Buffer.contents b
  in
  gen_id s

let id_of_string s =
  let n = String.length s in
  let out = Buffer.create 0 in
  (* Put [s] into [b], replacing non-alphanumeric characters with dashes. *)
  let rec loop started i =
    if i = n then ()
    else
      match s.[i] with
      | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' as c ->
        Buffer.add_char out c ;
        loop true (i + 1)
      (* Don't want to start with dashes. *)
      | _ when not started ->
        loop false (i + 1)
      | _ ->
        Buffer.add_char out '-' ;
        loop false (i + 1)
  in
  loop false 0 ;
  let s' = Buffer.contents out in
  if s' = "" then ""
  else
    (* Find out the index of the last character in [s'] that isn't a dash. *)
    let last_trailing = 
      let rec loop i =
        if i < 0 || s'.[i] <> '-' then i
        else loop (i - 1)
      in
      loop (String.length s' - 1)
    in
    (* Trim trailing dashes. *)
    String.sub s' 0 (last_trailing + 1)

let tests = [
  "Alphanumeric123";
  "some spaces";
  "...";
  "...abc";
  "";
  "...trailing non-alphanumeric!"
]

let () =
  List.iter
    (fun s ->
       Printf.printf "input: %s\nold_id_of_string: %s\nid_of_string: %s\n\n"
         s (old_id_of_string s) (id_of_string s))
    tests

```

This outputs:

```
input: Alphanumeric123
old_id_of_string: Alphanumeric123
id_of_string: Alphanumeric123

input: some spaces
old_id_of_string: somespaces
id_of_string: some-spaces

input: ...
old_id_of_string:
id_of_string:

input: ...abc
old_id_of_string: abc
id_of_string: abc

input:
old_id_of_string:
id_of_string:

input: ...trailing non-alphanumeric!
old_id_of_string: trailingnonalphanumeric
id_of_string: trailing-non-alphanumeric
```

Thanks for the software!