### PR TITLE
replaced s with Bytes.to_string s in omd_lexer.ml

### DIFF
--- a/src/omd_lexer.ml
+++ b/src/omd_lexer.ml
@@ -346,7 +346,7 @@ struct
       for i = 0 to len - 1 do
         String.unsafe_set s i (BA.Array1.unsafe_get arr (i + pos))
       done;
-      s
+      Bytes.to_string s
     end
 end
 module Lex_bigarray = Lex(Bigarray_input)


### PR DESCRIPTION
This is to correct the type signaure of sub, 
without this change the src doesnt compiles (The OCaml toplevel, version 4.06.2+dev0-2018-02-16) with the following error
```console
ocamldep omd_utils.ml omd_representation.ml omd_backend.ml omd_lexer.ml omd_parser.ml omd.ml omd_main.ml omd_utils.mli omd_representation.mli omd_backend.mli omd_lexer.mli omd_parser.mli omd.mli omd_main.mli > .depend
make cmis
make[1]: Entering directory '/home/tarptaeya/DevLangs/ocaml/omd/src'
make[1]: Nothing to be done for 'cmis'.
make[1]: Leaving directory '/home/tarptaeya/DevLangs/ocaml/omd/src'
make omd
make[1]: Entering directory '/home/tarptaeya/DevLangs/ocaml/omd/src'
ocamlopt.opt -g bigarray.cmxa -c omd_lexer.ml
File "omd_lexer.ml", line 344, characters 12-25:
Warning 3: deprecated: String.create
Use Bytes.create instead.
File "omd_lexer.ml", line 347, characters 8-25:
Warning 3: deprecated: String.unsafe_set
File "omd_lexer.ml", line 335, characters 0-406:
Error: Signature mismatch:
       ...
       Values do not match:
         val sub : (char, 'a, 'b) BA.Array1.t -> pos:int -> len:int -> bytes
       is not included in
         val sub : t -> pos:int -> len:int -> string
       File "omd_lexer.ml", line 188, characters 2-45: Expected declaration
       File "omd_lexer.ml", line 341, characters 6-9: Actual declaration
Makefile:27: recipe for target 'omd_lexer.cmx' failed
make[1]: *** [omd_lexer.cmx] Error 2
make[1]: Leaving directory '/home/tarptaeya/DevLangs/ocaml/omd/src'
Makefile:6: recipe for target 'all' failed
make: *** [all] Error 2
```