### PR TITLE
fix Inconsistent `code` vs. links parsing

### DIFF
--- a/src/backend.ml
+++ b/src/backend.ml
@@ -209,7 +209,7 @@ let rec html_and_headers_of_md
             begin match rc#get_ref name with
             | Some (href, title) ->
                 loop indent
-                  (Url (htmlentities ~md:true href, [Text(text)], htmlentities ~md:true title) :: tl)
+                  (Url (htmlentities ~md:true href, text, htmlentities ~md:true title) :: tl)
             | None ->
                 loop indent (fallback#to_t);
                 loop indent tl
@@ -563,7 +563,7 @@ let rec sexpr_of_md md =
         Buffer.add_string b ")";
         loop tl
     | Ref (_rc, name, text, _) :: tl ->
-        bprintf b "(Ref %S %S)" name text;
+        bprintf b "(Ref %S %S)" name (sexpr_of_md text);
         loop tl
     | Img_ref (_rc, name, alt, _) :: tl ->
         bprintf b "(Img_ref %S %S)" name alt;

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -61,7 +61,7 @@ and element = Representation.element =
   | NL (** Newline character.  Newline characters that act
            like delimiters (e.g. for paragraphs) are removed from the AST. *)
   | Url of href * t * title
-  | Ref of ref_container * name * string * fallback
+  | Ref of ref_container * name * t * fallback
   | Img_ref of ref_container * name * alt * fallback
   | Html of name * (string * string option) list * t
   | Html_block of name * (string * string option) list * t

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1094,10 +1094,12 @@ struct
         | [], remains ->
             let fallback = extract_fallback main_loop remains (Delim (1, Obracket) :: l) in
             let id = L.string_of_tokens text in (* implicit anchor *)
-            Some (Ref (rc, id, id, fallback) :: r, [Delim (1, Cbracket)], remains)
+            let contents = main_loop [] [] text in
+            Some (Ref (rc, id, contents, fallback) :: r, [Delim (1, Cbracket)], remains)
         | id, remains ->
             let fallback = extract_fallback main_loop remains (Delim (1, Obracket) :: l) in
-            Some(Ref (rc, L.string_of_tokens id, L.string_of_tokens text, fallback) :: r, [Delim (1, Cbracket)], remains)
+            let contents = main_loop [] [] text in
+            Some(Ref (rc, L.string_of_tokens id, contents, fallback) :: r, [Delim (1, Cbracket)], remains)
       end
     in
     let maybe_nonregular_ref l =
@@ -1107,7 +1109,8 @@ struct
         raise Premature_ending; (* <-- ill-placed open bracket *)
       let fallback = extract_fallback main_loop remains (Delim (1, Obracket) :: l) in
       let id = L.string_of_tokens text in (* implicit anchor *)
-      Some (Ref (rc, id, id, fallback) :: r, [Delim (1, Cbracket)], remains)
+      let contents = main_loop [] [] text in
+      Some (Ref (rc, id, contents, fallback) :: r, [Delim (1, Cbracket)], remains)
     in
     let maybe_def l =
       match read_until_cbracket ~bq:true l with

--- a/src/representation.mli
+++ b/src/representation.mli
@@ -24,7 +24,7 @@ type element =
   | Hr
   | NL
   | Url of href * t * title
-  | Ref of ref_container * name * string * fallback
+  | Ref of ref_container * name * t * fallback
   | Img_ref of ref_container * name * alt * fallback
   | Html of name * (string * string option) list * t
   | Html_block of name * (string * string option) list * t


### PR DESCRIPTION
fix https://github.com/ocaml/omd/issues/151

Warning: interface change

$ printf '[`bla bla`](http://example.com)\n' | omd
<p><a href='http://example.com'><code>bla bla</code></a></p>

Before:
 $ printf '[`bla bla`][some-ref]\n\n[some-ref]: http://example.com\n' | omd
<p><a href='http://example.com'>`bla bla`</a></p>
After:
 $ printf '[`bla bla`][some-ref]\n\n[some-ref]: http://example.com\n' | omd
<p><a href='http://example.com'><code>bla bla</code></a></p>

	modified:   src/backend.ml
	modified:   src/omd.mli
	modified:   src/parser.ml
	modified:   src/representation.ml
	modified:   src/representation.mli