### PR TITLE
Corrected linguist language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.ml* text eol=lf
 *.md text eol=lf
 *.html text eol=lf
+dune.inc linguist-generated=true


### PR DESCRIPTION
Just a little PR for the sake of clarity:

git-linguist detects the dune.inc files as php files, distorting the stats of the project, making it shown as mainly coded in php (~44,7% of php).

Kinda funny considering the "pure ocaml" mention :p

This pull-request does not change directly the language of .inc files, but as dune.inc files are auto-generated, it adds a git attribute, telling linguist to ignore those files