### PR TITLE
Added printer implementation for dumping modifications from the user

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -1,13 +1,3 @@
-[@@@warning "-30"]
-
-type list_kind =
-  | Ordered of int * char
-  | Unordered of char
-
-type list_style =
-  | Loose
-  | Tight
-
 type 'a link_def =
   {
     label: 'a;
@@ -15,71 +5,98 @@ type 'a link_def =
     title: string option;
   }
 
-type fenced_code_kind =
-  | Tilde
-  | Backtick
+module Block_list = struct
+  type kind =
+    | Ordered of int * char
+    | Unordered of char
 
-type 'a block_list =
+  type style =
+    | Loose
+    | Tight
+
+  type 'block t =
   {
-    list_kind: list_kind;
-    list_style: list_style;
-    blocks: 'a block list list;
+    kind: kind;
+    style: style;
+    blocks: 'block list list;
   }
-and code_block =
-  {
-    code_kind: fenced_code_kind option;
-    code_label: string option;
-    code_other: string option;
-    code: string option;
-  }
-and 'a block =
+end
+
+module Code_block = struct
+  type kind =
+    | Tilde
+    | Backtick
+
+  type t =
+    {
+      kind: kind option;
+      label: string option;
+      other: string option;
+      code: string option;
+    }
+end
+
+type 'a block =
   | Paragraph of 'a
-  | List of 'a block_list
+  | List of 'a block Block_list.t
   | Blockquote of 'a block list
   | Thematic_break
   | Heading of int * 'a
-  | Code_block of code_block
+  | Code_block of Code_block.t
   | Html_block of string
   | Link_def of string link_def
 
-type emph_kind =
-  | Normal
-  | Strong
+module Emph = struct
+  type kind =
+    | Normal
+    | Strong
 
-type emph_style =
-  | Star
-  | Underscore
+  type style =
+    | Star
+    | Underscore
+
+  type 'inline t =
+  {
+    style: style;
+    kind: kind;
+    content: 'inline
+  }
+end
 
 type link_kind =
   | Img
   | Url
 
-type emph =
+module Link = struct
+  type kind = link_kind
+
+  type 'inline t =
   {
-    kind: emph_kind;
-    style: emph_style;
-    md: inline;
+    kind: kind;
+    def: 'inline link_def;
   }
-and link =
+end
+
+module Ref = struct
+  type kind = link_kind
+
+  type 'inline t =
   {
-    kind: link_kind;
-    def: inline link_def;
-  }
-and ref =
-  {
-    kind: link_kind;
-    label: inline;
+    kind: kind;
+    label: 'inline;
     def: string link_def;
   }
-and inline =
+end
+
+type inline =
   | Concat of inline list
   | Text of string
-  | Emph of emph
+  | Emph of inline Emph.t
   | Code of int * string
   | Hard_break
   | Soft_break
-  | Link of link
-  | Ref of ref
+  | Link of inline Link.t
+  | Ref of inline Ref.t
   | Html of string
 
 let rec map f = function

--- a/src/block.ml
+++ b/src/block.ml
@@ -49,21 +49,21 @@ module Pre = struct
     match next with
     | Rblockquote state ->
         Blockquote (finish state) :: blocks
-    | Rlist (kind, style, _, _, closed_items, state) ->
-        List (kind, style, List.rev (finish state :: closed_items)) :: blocks
+    | Rlist (list_kind, list_style, _, _, closed_items, state) ->
+        List {list_kind; list_style; blocks = List.rev (finish state :: closed_items)} :: blocks
     | Rparagraph l ->
         let s = concat (List.map trim_left l) in
         let defs, off = Parser.link_reference_definitions (Parser.P.of_string s) in
         let s = String.sub s off (String.length s - off) |> String.trim in
         let blocks = List.fold_right (fun def blocks -> Link_def def :: blocks) defs blocks in
         if s = "" then blocks else Paragraph s :: blocks
-    | Rfenced_code (_, _, kind, info, []) ->
-        Code_block (Some (kind, info), None) :: blocks
-    | Rfenced_code (_, _, kind, info, l) ->
-        Code_block (Some (kind, info), Some (concat l)) :: blocks
+    | Rfenced_code (_, _, kind, (label, other), []) ->
+        Code_block {code_kind = Some kind; code_label = Some label; code_other = Some other; code = None} :: blocks
+    | Rfenced_code (_, _, kind, (label, other), l) ->
+        Code_block {code_kind = Some kind; code_label = Some label; code_other = Some other; code = Some (concat l)} :: blocks
     | Rindented_code l -> (* TODO: trim from the right *)
         let rec loop = function "" :: l -> loop l | _ as l -> l in
-        Code_block (None, Some (concat (loop l))) :: blocks
+        Code_block {code_kind = None; code_label = None; code_other = None; code = Some (concat (loop l))} :: blocks
     | Rhtml (_, l) ->
         Html_block (concat l) :: blocks
     | Rempty ->

--- a/src/block.mli
+++ b/src/block.mli
@@ -1,6 +1,6 @@
 open Ast
 
-val same_list_kind: list_kind -> list_kind -> bool
+val same_list_kind: Block_list.kind -> Block_list.kind -> bool
 
 type 'a t = 'a block
 

--- a/src/html.ml
+++ b/src/html.ml
@@ -1,5 +1,29 @@
 open Ast
 
+type printer =
+  {
+    start: printer          -> Buffer.t -> inline block list                                             -> unit;
+    finish: printer         -> Buffer.t                                                                  -> unit;
+    block: printer          -> Buffer.t -> inline block                                                  -> unit;
+    paragraph: printer      -> Buffer.t -> inline                                                        -> unit;
+    blockquote: printer     -> Buffer.t -> inline block list                                             -> unit;
+    list: printer           -> Buffer.t -> list_kind * list_style * inline block list list               -> unit;
+    code_block: printer     -> Buffer.t -> (fenced_code_kind * (string * string)) option * string option -> unit;
+    thematic_break: printer -> Buffer.t                                                                  -> unit;
+    html_block: printer     -> Buffer.t -> string                                                        -> unit;
+    heading: printer        -> Buffer.t -> int * inline                                                  -> unit;
+    inline: printer         -> Buffer.t -> inline                                                        -> unit;
+    concat: printer         -> Buffer.t -> inline list                                                   -> unit;
+    text: printer           -> Buffer.t -> string                                                        -> unit;
+    emph: printer           -> Buffer.t -> emph_kind * emph_style * inline                               -> unit;
+    code: printer           -> Buffer.t -> int * string                                                  -> unit;
+    hard_break: printer     -> Buffer.t                                                                  -> unit;
+    soft_break: printer     -> Buffer.t                                                                  -> unit;
+    html: printer           -> Buffer.t -> string                                                        -> unit;
+    link: printer           -> Buffer.t -> link_kind * inline link_def                                   -> unit;
+    ref: printer            -> Buffer.t -> link_kind * inline * string link_def                          -> unit;
+  }
+
 let _id_of_string ids s =
   let n = String.length s in
   let out = Buffer.create 0 in
@@ -77,128 +101,215 @@ let text_of_inline ast =
   Text.inline b ast;
   Buffer.contents b
 
-let rec html_of_md b md =
-  let rec loop = function
-    | Concat l ->
-        List.iter loop l
-    | Text t ->
-        Buffer.add_string b (htmlentities t)
-    | Emph (Normal, _, md) ->
-        Buffer.add_string b "<em>";
-        loop md;
-        Buffer.add_string b "</em>"
-    | Emph (Strong, _, md) ->
-        Buffer.add_string b "<strong>";
-        loop md;
-        Buffer.add_string b "</strong>"
-    | Code (_, c) ->
-        Buffer.add_string b "<code>";
-        Buffer.add_string b (htmlentities c);
-        Buffer.add_string b "</code>"
-    | Hard_break ->
-        Buffer.add_string b "<br />\n"
-    | Html body ->
-        Buffer.add_string b body
-    | Link (Url, {label; destination; title}) | Ref (Url, label, {destination; title; _}) ->
-        Buffer.add_string b "<a href=\"";
-        Buffer.add_string b (percent_encode destination);
-        Buffer.add_string b "\"";
-        begin match title with
-        | None -> ()
-        | Some title ->
-            Buffer.add_string b " title=\"";
-            Buffer.add_string b (htmlentities title);
-            Buffer.add_string b "\""
-        end;
-        Buffer.add_string b ">";
-        html_of_md b label;
-        Buffer.add_string b "</a>"
-    | Link (Img, {label; destination; title}) | Ref (Img, label, {destination; title; _}) ->
-        Buffer.add_string b "<img src=\"";
-        Buffer.add_string b (percent_encode destination);
-        Buffer.add_string b "\" alt=\"";
-        Buffer.add_string b (htmlentities (text_of_inline label));
-        Buffer.add_string b "\"";
-        begin match title with
-        | None -> ()
-        | Some title ->
-            Buffer.add_string b " title=\"";
-            Buffer.add_string b (htmlentities title);
-            Buffer.add_string b "\""
-        end;
-        Buffer.add_string b " />"
-    | Soft_break ->
-        Buffer.add_string b "\n"
-  in
-  loop md
+let start_print p b mds =
+  List.iter (function
+    | Link_def _ -> ()
+    | md ->
+        p.block p b md;
+        Buffer.add_char b '\n'
+    ) mds;
+  p.finish p b
 
-let to_html b md =
+let finish_print _ _ = ()
+
+let print_concat p b l =
+  List.iter (p.inline p b) l
+
+let print_text _ b t =
+  Buffer.add_string b (htmlentities t)
+
+let print_emph p b = function
+  | Normal, _, md ->
+      Buffer.add_string b "<em>";
+      p.inline p b md;
+      Buffer.add_string b "</em>"
+  | Strong, _, md ->
+      Buffer.add_string b "<strong>";
+      p.inline p b md;
+      Buffer.add_string b "</strong>"
+
+let print_code _ b (_, c) =
+  Buffer.add_string b "<code>";
+  Buffer.add_string b (htmlentities c);
+  Buffer.add_string b "</code>"
+
+let print_hard_break _ b =
+  Buffer.add_string b "<br />\n"
+
+let print_soft_break _ b =
+  Buffer.add_string b "\n"
+
+let print_html _ b body =
+  Buffer.add_string b body
+
+let print_url p b label destination title =
+  Buffer.add_string b "<a href=\"";
+  Buffer.add_string b (percent_encode destination);
+  Buffer.add_string b "\"";
+  begin match title with
+  | None -> ()
+  | Some title ->
+      Buffer.add_string b " title=\"";
+      Buffer.add_string b (htmlentities title);
+      Buffer.add_string b "\""
+  end;
+  Buffer.add_string b ">";
+  p.inline p b label;
+  Buffer.add_string b "</a>"
+
+let print_img b label destination title =
+  Buffer.add_string b "<img src=\"";
+  Buffer.add_string b (percent_encode destination);
+  Buffer.add_string b "\" alt=\"";
+  Buffer.add_string b (htmlentities (text_of_inline label));
+  Buffer.add_string b "\"";
+  begin match title with
+  | None -> ()
+  | Some title ->
+      Buffer.add_string b " title=\"";
+      Buffer.add_string b (htmlentities title);
+      Buffer.add_string b "\""
+  end;
+  Buffer.add_string b " />"
+
+let print_link p b = function
+  | Url, {label; destination; title} ->
+    print_url p b label destination title
+  | Img, {label; destination; title}  ->
+    print_img b label destination title
+
+let print_ref p b = function
+  | Url, label, {destination; title; _} ->
+    print_url p b label destination title
+  | Img, label, {destination; title; _} ->
+    print_img b label destination title
+
+let print_inline p b = function
+  | Concat l ->
+    p.concat p b l
+  | Text t ->
+    (* Format.eprintf "Text: %s\n" (id_of_string t); *)
+    p.text p b t
+  | Emph (kind, style, md) ->
+    p.emph p b (kind, style, md)
+  | Code (i, c) ->
+    p.code p b (i, c)
+  | Hard_break ->
+    p.hard_break p b
+  | Soft_break ->
+    p.soft_break p b
+  | Html body ->
+    p.html p b body
+  | Link (kind, link) ->
+    p.link p b (kind, link)
+  | Ref (kind, md, link) ->
+    p.ref p b (kind, md, link)
+
+let print_blockquote p b q =
   let iter_par f l = List.iter (function Link_def _ -> () | md -> f md) l in
-  let rec loop = function
-    | Blockquote q ->
-        Buffer.add_string b "<blockquote>\n";
-        iter_par (fun md -> loop md; Buffer.add_char b '\n') q;
-        Buffer.add_string b "</blockquote>"
-    | Paragraph md ->
-        Buffer.add_string b "<p>";
-        html_of_md b md;
-        Buffer.add_string b "</p>"
-    | List (kind, style, l) ->
-        Buffer.add_string b
-          (match kind with
-           | Ordered (1, _) -> "<ol>\n"
-           | Ordered (n, _) -> "<ol start=\"" ^ string_of_int n ^ "\">\n"
-           | Unordered _ -> "<ul>\n");
-        List.iter (fun x ->
-            Buffer.add_string b "<li>";
-            let _ = List.fold_left (li style) false x in
-            Buffer.add_string b "</li>\n"
-          ) l;
-        Buffer.add_string b
-          (match kind with Ordered _ -> "</ol>" | Unordered _ -> "</ul>")
-    | Code_block ((None | Some (_, ("", _))), None) ->
-        Buffer.add_string b "<pre><code></code></pre>"
-    | Code_block (Some (_, (info, _)), None) ->
-        Buffer.add_string b (Printf.sprintf "<pre><code class=\"language-%s\"></code></pre>" info)
-    | Code_block ((None | Some (_, ("", _))), Some c) ->
-        Buffer.add_string b "<pre><code>";
-        Buffer.add_string b (htmlentities c);
-        Buffer.add_string b "\n</code></pre>"
-    | Code_block (Some (_, (info, _)), Some c) ->
-        Printf.bprintf b "<pre><code class=\"language-%s\">" info;
-        Buffer.add_string b (htmlentities c);
-        Buffer.add_string b "\n</code></pre>"
-    | Thematic_break ->
-        Buffer.add_string b "<hr />"
-    | Html_block body ->
-        Buffer.add_string b body
-    | Heading (i, md) ->
-        Buffer.add_string b (Printf.sprintf "<h%d>" i);
-        html_of_md b md;
-        Buffer.add_string b (Printf.sprintf "</h%d>" i)
-    | Link_def _ ->
-        ()
-  and li style prev_nl x =
+  Buffer.add_string b "<blockquote>\n";
+  iter_par (fun md -> p.block p b md; Buffer.add_char b '\n') q;
+  Buffer.add_string b "</blockquote>"
+
+let print_paragraph p b md =
+  Buffer.add_string b "<p>";
+  p.inline p b md;
+  Buffer.add_string b "</p>"
+
+let print_list p b (kind, style, l) =
+  Buffer.add_string b
+    (match kind with
+      | Ordered (1, _) -> "<ol>\n"
+      | Ordered (n, _) -> "<ol start=\"" ^ string_of_int n ^ "\">\n"
+      | Unordered _ -> "<ul>\n");
+  let li style prev_nl x =
     match x, style with
     | Paragraph md, Tight ->
-        html_of_md b md;
+        p.inline p b md;
         false
     | Link_def _, _ ->
         prev_nl
     | _ ->
         if not prev_nl then Buffer.add_char b '\n';
-        loop x;
+        p.block p b x;
         Buffer.add_char b '\n';
-        true
-  in
-  loop md
+        true in
+  List.iter (fun x ->
+      Buffer.add_string b "<li>";
+      let _ = List.fold_left (li style) false x in
+      Buffer.add_string b "</li>\n"
+    ) l;
+  Buffer.add_string b
+    (match kind with Ordered _ -> "</ol>" | Unordered _ -> "</ul>")
 
-let to_html mds =
+let print_code_block _ b = function
+  | (None | Some (_, ("", _))), None ->
+      Buffer.add_string b "<pre><code></code></pre>"
+  | Some (_, (info, _)), None ->
+      Buffer.add_string b (Printf.sprintf "<pre><code class=\"language-%s\"></code></pre>" info)
+  | (None | Some (_, ("", _))), Some c ->
+      Buffer.add_string b "<pre><code>";
+      Buffer.add_string b (htmlentities c);
+      Buffer.add_string b "\n</code></pre>"
+  | Some (_, (info, _)), Some c ->
+      Printf.bprintf b "<pre><code class=\"language-%s\">" info;
+      Buffer.add_string b (htmlentities c);
+      Buffer.add_string b "\n</code></pre>"
+
+let print_thematic_break _ b =
+  Buffer.add_string b "<hr />"
+
+let print_html_block _ b body =
+  Buffer.add_string b body
+
+let print_heading p b (i, md) =
+  Buffer.add_string b (Printf.sprintf "<h%d>" i);
+  p.inline p b md;
+  Buffer.add_string b (Printf.sprintf "</h%d>" i)
+
+let print_block p b = function
+  | Blockquote q ->
+    p.blockquote p b q
+  | Paragraph md ->
+    p.paragraph p b md
+  | List (kind, style, l) ->
+    p.list p b (kind, style, l)
+  | Code_block (i, t) ->
+    p.code_block p b (i, t)
+  | Thematic_break ->
+    p.thematic_break p b
+  | Html_block body ->
+    p.html_block p b body
+  | Heading (i, md) ->
+    p.heading p b (i, md)
+  | Link_def _ ->
+    ()
+
+let default_printer =
+  {
+    start = start_print;
+    finish = finish_print;
+    block = print_block;
+    paragraph = print_paragraph;
+    blockquote = print_blockquote;
+    list = print_list;
+    code_block = print_code_block;
+    thematic_break = print_thematic_break;
+    html_block = print_html_block;
+    heading = print_heading;
+    inline = print_inline;
+    concat = print_concat;
+    text = print_text;
+    emph = print_emph;
+    code = print_code;
+    hard_break = print_hard_break;
+    soft_break = print_soft_break;
+    html = print_html;
+    link = print_link;
+    ref = print_ref;
+  }
+
+let to_html ?(printer=default_printer) mds =
   let b = Buffer.create 64 in
-  List.iter (function
-    | Link_def _ -> ()
-    | md ->
-        to_html b md;
-        Buffer.add_char b '\n'
-    ) mds;
+  printer.start printer b mds;
   Buffer.contents b

--- a/src/markdown.ml
+++ b/src/markdown.ml
@@ -53,12 +53,12 @@ let rec inline b = function
       List.iter (inline b) l
   | Text t ->
       Printf.bprintf b "%s" (escape_markdown_characters t)
-  | Emph {kind = Normal; style; md} ->
+  | Emph {kind = Normal; style; content} ->
       let q = match style with Star -> '*' | Underscore -> '_' in
-      Printf.bprintf b "%c%a%c" q inline md q
-  | Emph {kind = Strong; style; md} ->
+      Printf.bprintf b "%c%a%c" q inline content q
+  | Emph {kind = Strong; style; content} ->
       let q = match style with Star -> '*' | Underscore -> '_' in
-      Printf.bprintf b "%c%c%a%c%c" q q inline md q q
+      Printf.bprintf b "%c%c%a%c%c" q q inline content q q
   | Code (n, c) ->
       let d = String.make n '`' in
       Printf.bprintf b "%s%s%s" d c d

--- a/src/markdown.ml
+++ b/src/markdown.ml
@@ -53,11 +53,11 @@ let rec inline b = function
       List.iter (inline b) l
   | Text t ->
       Printf.bprintf b "%s" (escape_markdown_characters t)
-  | Emph (Normal, q, md) ->
-      let q = match q with Star -> '*' | Underscore -> '_' in
+  | Emph {kind = Normal; style; md} ->
+      let q = match style with Star -> '*' | Underscore -> '_' in
       Printf.bprintf b "%c%a%c" q inline md q
-  | Emph (Strong, q, md) ->
-      let q = match q with Star -> '*' | Underscore -> '_' in
+  | Emph {kind = Strong; style; md} ->
+      let q = match style with Star -> '*' | Underscore -> '_' in
       Printf.bprintf b "%c%c%a%c%c" q q inline md q q
   | Code (n, c) ->
       let d = String.make n '`' in
@@ -66,18 +66,18 @@ let rec inline b = function
       Buffer.add_string b "<br />"
   | Html body ->
       Buffer.add_string b body
-  | Link (Url, {label; destination; title = None}) ->
+  | Link {kind = Url; def = {label; destination; title = None}} ->
       Printf.bprintf b "[%a](%s)" inline label destination
-  | Link (Img, {label; destination; title = None}) ->
+  | Link {kind = Img; def = {label; destination; title = None}} ->
       Printf.bprintf b "![%a](%s)" inline label (* FIXME *) destination
-  | Link (Url, {label; destination; title = Some title}) ->
+  | Link {kind = Url; def = {label; destination; title = Some title}} ->
       Printf.bprintf b "[%a](%s \"%s\")" inline label destination title
-  | Link (Img, {label; destination; title = Some title}) ->
+  | Link {kind = Img; def = {label; destination; title = Some title}} ->
       Printf.bprintf b "![%a](%s \"%s\")" inline label (* FIXME *) destination title
-  | Ref (Url, label, {Ast.label = label1; _}) ->
-      Printf.bprintf b "[%a][%s]" inline label label1
-  | Ref (Img, label, {Ast.label = label1; _}) ->
-      Printf.bprintf b "![%a][%s]" inline label label1
+  | Ref {kind = Url; label; def = {Ast.label = label'; _}} ->
+      Printf.bprintf b "[%a][%s]" inline label label'
+  | Ref {kind = Img; label; def = {Ast.label = label'; _}} ->
+      Printf.bprintf b "![%a][%s]" inline label label'
   | Soft_break ->
       if Buffer.length b = 1 ||
          (Buffer.length b > 1 &&

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -2,25 +2,25 @@ include Ast
 
 type printer = Html.printer =
   {
-    document: printer       -> Buffer.t -> inline block list -> unit;
-    block: printer          -> Buffer.t -> inline block      -> unit;
-    paragraph: printer      -> Buffer.t -> inline            -> unit;
-    blockquote: printer     -> Buffer.t -> inline block list -> unit;
-    list: printer           -> Buffer.t -> inline block_list -> unit;
-    code_block: printer     -> Buffer.t -> code_block        -> unit;
-    thematic_break: printer -> Buffer.t                      -> unit;
-    html_block: printer     -> Buffer.t -> string            -> unit;
-    heading: printer        -> Buffer.t -> int -> inline     -> unit;
-    inline: printer         -> Buffer.t -> inline            -> unit;
-    concat: printer         -> Buffer.t -> inline list       -> unit;
-    text: printer           -> Buffer.t -> string            -> unit;
-    emph: printer           -> Buffer.t -> emph              -> unit;
-    code: printer           -> Buffer.t -> int -> string     -> unit;
-    hard_break: printer     -> Buffer.t                      -> unit;
-    soft_break: printer     -> Buffer.t                      -> unit;
-    html: printer           -> Buffer.t -> string            -> unit;
-    link: printer           -> Buffer.t -> link              -> unit;
-    ref: printer            -> Buffer.t -> ref               -> unit;
+    document: printer       -> Buffer.t -> inline block list         -> unit;
+    block: printer          -> Buffer.t -> inline block              -> unit;
+    paragraph: printer      -> Buffer.t -> inline                    -> unit;
+    blockquote: printer     -> Buffer.t -> inline block list         -> unit;
+    list: printer           -> Buffer.t -> inline block Block_list.t -> unit;
+    code_block: printer     -> Buffer.t -> Code_block.t              -> unit;
+    thematic_break: printer -> Buffer.t                              -> unit;
+    html_block: printer     -> Buffer.t -> string                    -> unit;
+    heading: printer        -> Buffer.t -> int -> inline             -> unit;
+    inline: printer         -> Buffer.t -> inline                    -> unit;
+    concat: printer         -> Buffer.t -> inline list               -> unit;
+    text: printer           -> Buffer.t -> string                    -> unit;
+    emph: printer           -> Buffer.t -> inline Emph.t             -> unit;
+    code: printer           -> Buffer.t -> int -> string             -> unit;
+    hard_break: printer     -> Buffer.t                              -> unit;
+    soft_break: printer     -> Buffer.t                              -> unit;
+    html: printer           -> Buffer.t -> string                    -> unit;
+    link: printer           -> Buffer.t -> inline Link.t             -> unit;
+    ref: printer            -> Buffer.t -> inline Ref.t              -> unit;
   }
 
 type t = inline block list

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -2,25 +2,25 @@ include Ast
 
 type printer = Html.printer =
   {
-    document: printer       -> Buffer.t -> inline block list                                              -> unit;
-    block: printer          -> Buffer.t -> inline block                                                   -> unit;
-    paragraph: printer      -> Buffer.t -> inline                                                         -> unit;
-    blockquote: printer     -> Buffer.t -> inline block list                                              -> unit;
-    list: printer           -> Buffer.t -> list_kind -> list_style -> inline block list list              -> unit;
-    code_block: printer     -> Buffer.t -> (fenced_code_kind * (string * string)) option -> string option -> unit;
-    thematic_break: printer -> Buffer.t                                                                   -> unit;
-    html_block: printer     -> Buffer.t -> string                                                         -> unit;
-    heading: printer        -> Buffer.t -> int -> inline                                                  -> unit;
-    inline: printer         -> Buffer.t -> inline                                                         -> unit;
-    concat: printer         -> Buffer.t -> inline list                                                    -> unit;
-    text: printer           -> Buffer.t -> string                                                         -> unit;
-    emph: printer           -> Buffer.t -> emph_kind -> emph_style -> inline                              -> unit;
-    code: printer           -> Buffer.t -> int -> string                                                  -> unit;
-    hard_break: printer     -> Buffer.t                                                                   -> unit;
-    soft_break: printer     -> Buffer.t                                                                   -> unit;
-    html: printer           -> Buffer.t -> string                                                         -> unit;
-    link: printer           -> Buffer.t -> link_kind -> inline link_def                                   -> unit;
-    ref: printer            -> Buffer.t -> link_kind -> inline -> string link_def                         -> unit;
+    document: printer       -> Buffer.t -> inline block list -> unit;
+    block: printer          -> Buffer.t -> inline block      -> unit;
+    paragraph: printer      -> Buffer.t -> inline            -> unit;
+    blockquote: printer     -> Buffer.t -> inline block list -> unit;
+    list: printer           -> Buffer.t -> inline block_list -> unit;
+    code_block: printer     -> Buffer.t -> code_block        -> unit;
+    thematic_break: printer -> Buffer.t                      -> unit;
+    html_block: printer     -> Buffer.t -> string            -> unit;
+    heading: printer        -> Buffer.t -> int -> inline     -> unit;
+    inline: printer         -> Buffer.t -> inline            -> unit;
+    concat: printer         -> Buffer.t -> inline list       -> unit;
+    text: printer           -> Buffer.t -> string            -> unit;
+    emph: printer           -> Buffer.t -> emph              -> unit;
+    code: printer           -> Buffer.t -> int -> string     -> unit;
+    hard_break: printer     -> Buffer.t                      -> unit;
+    soft_break: printer     -> Buffer.t                      -> unit;
+    html: printer           -> Buffer.t -> string            -> unit;
+    link: printer           -> Buffer.t -> link              -> unit;
+    ref: printer            -> Buffer.t -> ref               -> unit;
   }
 
 type t = inline block list
@@ -29,7 +29,7 @@ let parse_inlines md =
   let parse_inline defs s = Parser.inline defs (Parser.P.of_string s) in
   let defs = Ast.defs md in
   let defs =
-    List.map (fun def -> {def with Ast.label = Parser.normalize def.label}) defs
+    List.map (fun (def: string link_def) -> {def with Ast.label = Parser.normalize def.label}) defs
   in
   List.map (Ast.map (parse_inline defs)) md
 

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -1,5 +1,7 @@
 include Ast
 
+type printer = Html.printer
+
 type t = inline block list
 
 let parse_inlines md =
@@ -18,8 +20,10 @@ let of_string s =
   let md = Block.Pre.of_string s in
   parse_inlines md
 
-let to_html doc =
-  Html.to_html doc
+let default_printer = Html.default_printer
+
+let to_html ?printer doc =
+  Html.to_html ?printer doc
 
 let to_sexp ast =
   Format.asprintf "@[%a@]@." Sexp.print (Sexp.create ast)

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -1,6 +1,27 @@
 include Ast
 
-type printer = Html.printer
+type printer = Html.printer =
+  {
+    document: printer       -> Buffer.t -> inline block list                                              -> unit;
+    block: printer          -> Buffer.t -> inline block                                                   -> unit;
+    paragraph: printer      -> Buffer.t -> inline                                                         -> unit;
+    blockquote: printer     -> Buffer.t -> inline block list                                              -> unit;
+    list: printer           -> Buffer.t -> list_kind -> list_style -> inline block list list              -> unit;
+    code_block: printer     -> Buffer.t -> (fenced_code_kind * (string * string)) option -> string option -> unit;
+    thematic_break: printer -> Buffer.t                                                                   -> unit;
+    html_block: printer     -> Buffer.t -> string                                                         -> unit;
+    heading: printer        -> Buffer.t -> int -> inline                                                  -> unit;
+    inline: printer         -> Buffer.t -> inline                                                         -> unit;
+    concat: printer         -> Buffer.t -> inline list                                                    -> unit;
+    text: printer           -> Buffer.t -> string                                                         -> unit;
+    emph: printer           -> Buffer.t -> emph_kind -> emph_style -> inline                              -> unit;
+    code: printer           -> Buffer.t -> int -> string                                                  -> unit;
+    hard_break: printer     -> Buffer.t                                                                   -> unit;
+    soft_break: printer     -> Buffer.t                                                                   -> unit;
+    html: printer           -> Buffer.t -> string                                                         -> unit;
+    link: printer           -> Buffer.t -> link_kind -> inline link_def                                   -> unit;
+    ref: printer            -> Buffer.t -> link_kind -> inline -> string link_def                         -> unit;
+  }
 
 type t = inline block list
 

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -1,5 +1,7 @@
 (** A markdown parser in OCaml. *)
 
+[@@@warning "-30"]
+
 type list_kind = Ast.list_kind =
   | Ordered of int * char
   | Unordered of char
@@ -19,13 +21,26 @@ type fenced_code_kind = Ast.fenced_code_kind =
   | Tilde
   | Backtick
 
-type 'a block = 'a Ast.block =
+type 'a block_list = 'a Ast.block_list =
+  {
+    list_kind: list_kind;
+    list_style: list_style;
+    blocks: 'a block list list;
+  }
+and code_block = Ast.code_block =
+  {
+    code_kind: fenced_code_kind option;
+    code_label: string option;
+    code_other: string option;
+    code: string option;
+  }
+and 'a block = 'a Ast.block =
   | Paragraph of 'a
-  | List of list_kind * list_style * 'a block list list
+  | List of 'a block_list
   | Blockquote of 'a block list
   | Thematic_break
   | Heading of int * 'a
-  | Code_block of (fenced_code_kind * (string * string)) option * string option
+  | Code_block of code_block
   | Html_block of string
   | Link_def of string link_def
 
@@ -41,15 +56,32 @@ type link_kind = Ast.link_kind =
   | Img
   | Url
 
-type inline = Ast.inline =
+type emph = Ast.emph =
+  {
+    kind: emph_kind;
+    style: emph_style;
+    md: inline;
+  }
+and link = Ast.link =
+  {
+    kind: link_kind;
+    def: inline link_def;
+  }
+and ref = Ast.ref =
+  {
+    kind: link_kind;
+    label: inline;
+    def: string link_def;
+  }
+and inline = Ast.inline =
   | Concat of inline list
   | Text of string
-  | Emph of emph_kind * emph_style * inline
+  | Emph of emph
   | Code of int * string
   | Hard_break
   | Soft_break
-  | Link of link_kind * inline link_def
-  | Ref of link_kind * inline * string link_def
+  | Link of link
+  | Ref of ref
   | Html of string
 
 type t = inline block list
@@ -57,25 +89,25 @@ type t = inline block list
 
 type printer = Html.printer =
   {
-    document: printer       -> Buffer.t -> inline block list                                              -> unit;
-    block: printer          -> Buffer.t -> inline block                                                   -> unit;
-    paragraph: printer      -> Buffer.t -> inline                                                         -> unit;
-    blockquote: printer     -> Buffer.t -> inline block list                                              -> unit;
-    list: printer           -> Buffer.t -> list_kind -> list_style -> inline block list list              -> unit;
-    code_block: printer     -> Buffer.t -> (fenced_code_kind * (string * string)) option -> string option -> unit;
-    thematic_break: printer -> Buffer.t                                                                   -> unit;
-    html_block: printer     -> Buffer.t -> string                                                         -> unit;
-    heading: printer        -> Buffer.t -> int -> inline                                                  -> unit;
-    inline: printer         -> Buffer.t -> inline                                                         -> unit;
-    concat: printer         -> Buffer.t -> inline list                                                    -> unit;
-    text: printer           -> Buffer.t -> string                                                         -> unit;
-    emph: printer           -> Buffer.t -> emph_kind -> emph_style -> inline                              -> unit;
-    code: printer           -> Buffer.t -> int -> string                                                  -> unit;
-    hard_break: printer     -> Buffer.t                                                                   -> unit;
-    soft_break: printer     -> Buffer.t                                                                   -> unit;
-    html: printer           -> Buffer.t -> string                                                         -> unit;
-    link: printer           -> Buffer.t -> link_kind -> inline link_def                                   -> unit;
-    ref: printer            -> Buffer.t -> link_kind -> inline -> string link_def                         -> unit;
+    document: printer       -> Buffer.t -> inline block list -> unit;
+    block: printer          -> Buffer.t -> inline block      -> unit;
+    paragraph: printer      -> Buffer.t -> inline            -> unit;
+    blockquote: printer     -> Buffer.t -> inline block list -> unit;
+    list: printer           -> Buffer.t -> inline block_list -> unit;
+    code_block: printer     -> Buffer.t -> code_block        -> unit;
+    thematic_break: printer -> Buffer.t                      -> unit;
+    html_block: printer     -> Buffer.t -> string            -> unit;
+    heading: printer        -> Buffer.t -> int -> inline     -> unit;
+    inline: printer         -> Buffer.t -> inline            -> unit;
+    concat: printer         -> Buffer.t -> inline list       -> unit;
+    text: printer           -> Buffer.t -> string            -> unit;
+    emph: printer           -> Buffer.t -> emph              -> unit;
+    code: printer           -> Buffer.t -> int -> string     -> unit;
+    hard_break: printer     -> Buffer.t                      -> unit;
+    soft_break: printer     -> Buffer.t                      -> unit;
+    html: printer           -> Buffer.t -> string            -> unit;
+    link: printer           -> Buffer.t -> link              -> unit;
+    ref: printer            -> Buffer.t -> ref               -> unit;
   }
 
 val of_channel: in_channel -> t

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -1,15 +1,5 @@
 (** A markdown parser in OCaml. *)
 
-[@@@warning "-30"]
-
-type list_kind = Ast.list_kind =
-  | Ordered of int * char
-  | Unordered of char
-
-type list_style = Ast.list_style =
-  | Loose
-  | Tight
-
 type 'a link_def = 'a Ast.link_def =
   {
     label: 'a;
@@ -17,71 +7,32 @@ type 'a link_def = 'a Ast.link_def =
     title: string option;
   }
 
-type fenced_code_kind = Ast.fenced_code_kind =
-  | Tilde
-  | Backtick
+module Block_list = Ast.Block_list
+module Code_block = Ast.Code_block
 
-type 'a block_list = 'a Ast.block_list =
-  {
-    list_kind: list_kind;
-    list_style: list_style;
-    blocks: 'a block list list;
-  }
-and code_block = Ast.code_block =
-  {
-    code_kind: fenced_code_kind option;
-    code_label: string option;
-    code_other: string option;
-    code: string option;
-  }
-and 'a block = 'a Ast.block =
+type 'a block = 'a Ast.block =
   | Paragraph of 'a
-  | List of 'a block_list
+  | List of 'a block Block_list.t
   | Blockquote of 'a block list
   | Thematic_break
   | Heading of int * 'a
-  | Code_block of code_block
+  | Code_block of Code_block.t
   | Html_block of string
   | Link_def of string link_def
 
-type emph_kind = Ast.emph_kind =
-  | Normal
-  | Strong
+module Emph = Ast.Emph
+module Link = Ast.Link
+module Ref = Ast.Ref
 
-type emph_style = Ast.emph_style =
-  | Star
-  | Underscore
-
-type link_kind = Ast.link_kind =
-  | Img
-  | Url
-
-type emph = Ast.emph =
-  {
-    kind: emph_kind;
-    style: emph_style;
-    md: inline;
-  }
-and link = Ast.link =
-  {
-    kind: link_kind;
-    def: inline link_def;
-  }
-and ref = Ast.ref =
-  {
-    kind: link_kind;
-    label: inline;
-    def: string link_def;
-  }
-and inline = Ast.inline =
+type inline = Ast.inline =
   | Concat of inline list
   | Text of string
-  | Emph of emph
+  | Emph of inline Emph.t
   | Code of int * string
   | Hard_break
   | Soft_break
-  | Link of link
-  | Ref of ref
+  | Link of inline Link.t
+  | Ref of inline Ref.t
   | Html of string
 
 type t = inline block list
@@ -89,25 +40,25 @@ type t = inline block list
 
 type printer = Html.printer =
   {
-    document: printer       -> Buffer.t -> inline block list -> unit;
-    block: printer          -> Buffer.t -> inline block      -> unit;
-    paragraph: printer      -> Buffer.t -> inline            -> unit;
-    blockquote: printer     -> Buffer.t -> inline block list -> unit;
-    list: printer           -> Buffer.t -> inline block_list -> unit;
-    code_block: printer     -> Buffer.t -> code_block        -> unit;
-    thematic_break: printer -> Buffer.t                      -> unit;
-    html_block: printer     -> Buffer.t -> string            -> unit;
-    heading: printer        -> Buffer.t -> int -> inline     -> unit;
-    inline: printer         -> Buffer.t -> inline            -> unit;
-    concat: printer         -> Buffer.t -> inline list       -> unit;
-    text: printer           -> Buffer.t -> string            -> unit;
-    emph: printer           -> Buffer.t -> emph              -> unit;
-    code: printer           -> Buffer.t -> int -> string     -> unit;
-    hard_break: printer     -> Buffer.t                      -> unit;
-    soft_break: printer     -> Buffer.t                      -> unit;
-    html: printer           -> Buffer.t -> string            -> unit;
-    link: printer           -> Buffer.t -> link              -> unit;
-    ref: printer            -> Buffer.t -> ref               -> unit;
+    document: printer       -> Buffer.t -> inline block list         -> unit;
+    block: printer          -> Buffer.t -> inline block              -> unit;
+    paragraph: printer      -> Buffer.t -> inline                    -> unit;
+    blockquote: printer     -> Buffer.t -> inline block list         -> unit;
+    list: printer           -> Buffer.t -> inline block Block_list.t -> unit;
+    code_block: printer     -> Buffer.t -> Code_block.t              -> unit;
+    thematic_break: printer -> Buffer.t                              -> unit;
+    html_block: printer     -> Buffer.t -> string                    -> unit;
+    heading: printer        -> Buffer.t -> int -> inline             -> unit;
+    inline: printer         -> Buffer.t -> inline                    -> unit;
+    concat: printer         -> Buffer.t -> inline list               -> unit;
+    text: printer           -> Buffer.t -> string                    -> unit;
+    emph: printer           -> Buffer.t -> inline Emph.t             -> unit;
+    code: printer           -> Buffer.t -> int -> string             -> unit;
+    hard_break: printer     -> Buffer.t                              -> unit;
+    soft_break: printer     -> Buffer.t                              -> unit;
+    html: printer           -> Buffer.t -> string                    -> unit;
+    link: printer           -> Buffer.t -> inline Link.t             -> unit;
+    ref: printer            -> Buffer.t -> inline Ref.t              -> unit;
   }
 
 val of_channel: in_channel -> t

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -55,10 +55,14 @@ type inline =
 type t = inline block list
 (** A markdown document *)
 
+type printer = Html.printer
+
 val of_channel: in_channel -> t
 
 val of_string: string -> t
 
-val to_html: t -> string
+val default_printer: printer
+
+val to_html: ?printer:printer -> t -> string
 
 val to_sexp: t -> string

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -1,25 +1,25 @@
 (** A markdown parser in OCaml. *)
 
-type list_kind =
+type list_kind = Ast.list_kind =
   | Ordered of int * char
   | Unordered of char
 
-type list_style =
+type list_style = Ast.list_style =
   | Loose
   | Tight
 
-type 'a link_def =
+type 'a link_def = 'a Ast.link_def =
   {
     label: 'a;
     destination: string;
     title: string option;
   }
 
-type fenced_code_kind =
+type fenced_code_kind = Ast.fenced_code_kind =
   | Tilde
   | Backtick
 
-type 'a block =
+type 'a block = 'a Ast.block =
   | Paragraph of 'a
   | List of list_kind * list_style * 'a block list list
   | Blockquote of 'a block list
@@ -29,19 +29,19 @@ type 'a block =
   | Html_block of string
   | Link_def of string link_def
 
-type emph_kind =
+type emph_kind = Ast.emph_kind =
   | Normal
   | Strong
 
-type emph_style =
+type emph_style = Ast.emph_style =
   | Star
   | Underscore
 
-type link_kind =
+type link_kind = Ast.link_kind =
   | Img
   | Url
 
-type inline =
+type inline = Ast.inline =
   | Concat of inline list
   | Text of string
   | Emph of emph_kind * emph_style * inline
@@ -55,7 +55,28 @@ type inline =
 type t = inline block list
 (** A markdown document *)
 
-type printer = Html.printer
+type printer = Html.printer =
+  {
+    document: printer       -> Buffer.t -> inline block list                                              -> unit;
+    block: printer          -> Buffer.t -> inline block                                                   -> unit;
+    paragraph: printer      -> Buffer.t -> inline                                                         -> unit;
+    blockquote: printer     -> Buffer.t -> inline block list                                              -> unit;
+    list: printer           -> Buffer.t -> list_kind -> list_style -> inline block list list              -> unit;
+    code_block: printer     -> Buffer.t -> (fenced_code_kind * (string * string)) option -> string option -> unit;
+    thematic_break: printer -> Buffer.t                                                                   -> unit;
+    html_block: printer     -> Buffer.t -> string                                                         -> unit;
+    heading: printer        -> Buffer.t -> int -> inline                                                  -> unit;
+    inline: printer         -> Buffer.t -> inline                                                         -> unit;
+    concat: printer         -> Buffer.t -> inline list                                                    -> unit;
+    text: printer           -> Buffer.t -> string                                                         -> unit;
+    emph: printer           -> Buffer.t -> emph_kind -> emph_style -> inline                              -> unit;
+    code: printer           -> Buffer.t -> int -> string                                                  -> unit;
+    hard_break: printer     -> Buffer.t                                                                   -> unit;
+    soft_break: printer     -> Buffer.t                                                                   -> unit;
+    html: printer           -> Buffer.t -> string                                                         -> unit;
+    link: printer           -> Buffer.t -> link_kind -> inline link_def                                   -> unit;
+    ref: printer            -> Buffer.t -> link_kind -> inline -> string link_def                         -> unit;
+  }
 
 val of_channel: in_channel -> t
 

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -265,10 +265,10 @@ type t =
   | Lthematic_break
   | Latx_heading of int * string
   | Lsetext_heading of int * int
-  | Lfenced_code of int * int * Ast.fenced_code_kind * (string * string)
+  | Lfenced_code of int * int * Code_block.kind * (string * string)
   | Lindented_code of Sub.t
   | Lhtml of bool * html_kind
-  | Llist_item of Ast.list_kind * int * Sub.t
+  | Llist_item of Block_list.kind * int * Sub.t
   | Lparagraph
 
 let sp3 s =
@@ -461,7 +461,7 @@ let fenced_code ind s =
         | Some _ | None ->
             if n < 3 then raise Fail;
             let s = info_string c s in
-            let c = if c = '`' then Backtick else Tilde in
+            let c = if c = '`' then Code_block.Backtick else Tilde in
             Lfenced_code (ind, n, c, s)
       in
       loop 1 (Sub.tail s)
@@ -818,8 +818,8 @@ module Pre = struct
 
   type t =
     | Bang_left_bracket
-    | Left_bracket of Ast.link_kind
-    | Emph of delim * delim * emph_style * int
+    | Left_bracket of Link.kind
+    | Emph of delim * delim * Emph.style * int
     | R of inline
 
   let concat = function
@@ -879,8 +879,8 @@ module Pre = struct
                 if n2 > 1 then Emph (Punct, post, q2, n2-1) :: xs else xs
               in
               let r =
-                let kind = if n1 >= 2 && n2 >= 2 then Strong else Normal in
-                R (Emph {kind; style = q1; md = concat (List.map to_r (parse_emph (List.rev acc)))}) :: xs
+                let kind = if n1 >= 2 && n2 >= 2 then Emph.Strong else Emph.Normal in
+                R (Emph {kind; style = q1; content = concat (List.map to_r (parse_emph (List.rev acc)))}) :: xs
               in
               let r =
                 if n1 >= 2 && n2 >= 2 then
@@ -1618,7 +1618,7 @@ let rec inline defs st =
         let f post n st =
           let pre = pre |> Pre.classify_delim in
           let post = post |> Pre.classify_delim in
-          let e = if c = '*' then Ast.Star else Underscore in
+          let e = if c = '*' then Emph.Star else Emph.Underscore in
           loop (Pre.Emph (pre, post, e, n) :: text acc) st
         in
         let rec aux n =

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -16,43 +16,43 @@ and inline = function
       List (Atom "concat" :: List.map inline xs)
   | Text s ->
       Atom s
-  | Emph (_, _, x) ->
-      List [Atom "emph"; inline x]
+  | Emph e ->
+      List [Atom "emph"; inline e.md]
   | Code _ ->
       Atom "code"
   | Hard_break ->
       Atom "hard-break"
   | Soft_break ->
       Atom "soft-break"
-  | Link (Url, def) ->
+  | Link {kind = Url; def} ->
       List [Atom "url"; link_def inline def]
-  | Ref (Url, label, def) ->
+  | Ref {kind = Url; label; def} ->
       List [Atom "url-ref"; inline label; link_def atom def]
   | Html s ->
       List [Atom "html"; Atom s]
-  | Link (Img, _) ->
+  | Link {kind = Img; _} ->
       Atom "img"
-  | Ref (Img, label, def) ->
+  | Ref {kind = Img; label; def} ->
       List [Atom "img-ref"; inline label; link_def atom def]
 
 let rec block = function
   | Paragraph x ->
       List [Atom "paragraph"; inline x]
-  | List (_, _, xs) ->
-      List (Atom "list" :: List.map (fun xs -> List (Atom "list-item" :: List.map block xs)) xs)
+  | List l ->
+      List (Atom "list" :: List.map (fun xs -> List (Atom "list-item" :: List.map block xs)) l.blocks)
   | Blockquote xs ->
       List (Atom "blockquote" :: List.map block xs)
   | Thematic_break ->
       Atom "thematic-break"
   | Heading (n, x) ->
       List [Atom "heading"; Atom (string_of_int n); inline x]
-  | Code_block (None, Some s) ->
+  | Code_block {code_kind = None; code = Some s; _} ->
       List [Atom "indented-code"; Atom s]
-  | Code_block (None, None) ->
+  | Code_block {code_kind = None; code = None; _} ->
       List [Atom "indented-code"]
-  | Code_block (Some _, Some s) ->
+  | Code_block {code_kind = Some _; code = Some s; _} ->
       List [Atom "fenced-code"; Atom s]
-  | Code_block (Some _, None) ->
+  | Code_block {code_kind = Some _; code = None; _} ->
       List [Atom "fenced-code"]
   | Html_block s ->
       List [Atom "html"; Atom s]

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -17,7 +17,7 @@ and inline = function
   | Text s ->
       Atom s
   | Emph e ->
-      List [Atom "emph"; inline e.md]
+      List [Atom "emph"; inline e.content]
   | Code _ ->
       Atom "code"
   | Hard_break ->
@@ -46,13 +46,13 @@ let rec block = function
       Atom "thematic-break"
   | Heading (n, x) ->
       List [Atom "heading"; Atom (string_of_int n); inline x]
-  | Code_block {code_kind = None; code = Some s; _} ->
+  | Code_block {kind = None; code = Some s; _} ->
       List [Atom "indented-code"; Atom s]
-  | Code_block {code_kind = None; code = None; _} ->
+  | Code_block {kind = None; code = None; _} ->
       List [Atom "indented-code"]
-  | Code_block {code_kind = Some _; code = Some s; _} ->
+  | Code_block {kind = Some _; code = Some s; _} ->
       List [Atom "fenced-code"; Atom s]
-  | Code_block {code_kind = Some _; code = None; _} ->
+  | Code_block {kind = Some _; code = None; _} ->
       List [Atom "fenced-code"]
   | Html_block s ->
       List [Atom "html"; Atom s]

--- a/src/text.ml
+++ b/src/text.ml
@@ -5,8 +5,8 @@ let rec inline b = function
       List.iter (inline b) l
   | Text t ->
       Buffer.add_string b t
-  | Emph (_, _, md) ->
-      inline b md
+  | Emph e ->
+      inline b e.md
   | Code (n, s) ->
       let d = String.make n '`' in
       Printf.bprintf b "%s%s%s" d s d
@@ -14,18 +14,13 @@ let rec inline b = function
       Buffer.add_char b '\n'
   | Html body ->
       Buffer.add_string b body
-  | Link (_, {label; _}) | Ref (_, label, _) ->
-      inline b label
+  | Link l ->
+      inline b l.def.label
+  | Ref r ->
+      inline b r.label
 
 let block f b = function
   | Paragraph x ->
       f b x
   | _ ->
       assert false
-  (* | List of list_kind * list_style * 'a block list list *)
-  (* | Blockquote of 'a block list *)
-  (* | Thematic_break *)
-  (* | Heading of int * 'a *)
-  (* | Code_block of (fenced_code_kind * string) option * string option *)
-  (* | Html_block of string *)
-  (* | Link_def of 'a link_def *)

--- a/src/text.ml
+++ b/src/text.ml
@@ -6,7 +6,7 @@ let rec inline b = function
   | Text t ->
       Buffer.add_string b t
   | Emph e ->
-      inline b e.md
+      inline b e.content
   | Code (n, s) ->
       let d = String.make n '`' in
       Printf.bprintf b "%s%s%s" d s d


### PR DESCRIPTION
This pull request is part of the work needed for this [issue](https://github.com/ocaml/omd/issues/175):
In order to modify the behaviour of omd from the user, I added a printer record, containing the printing functions.
It allows the user to redefine their behaviour by creating a new record with the new functions, then give it as an argument for the to_html function.

For example, the following code wraps the headings in a section (ugly code, could be better, just for example):
```ocaml
let printer =
  let headings = ref [] in
  in
  let print_heading (p: Omd.printer) b (i, md) =
    let f j =
      if i <= j
      then
        (Buffer.add_string b (Printf.sprintf "</section>\n"); false)
      else
        true in
    headings := i::(List.filter f !headings);
    let id = Buffer.create 64 in
    Buffer.add_string b (Printf.sprintf "<section>\n<h%d>" (Bytes.to_string (Buffer.to_bytes id)) i i);
    p.inline p b md;
    Buffer.add_string b (Printf.sprintf "</h%d>" i);
  in
  let finish_print _ b =
    List.iter (fun _ -> Buffer.add_string b (Printf.sprintf "</section>\n")) !headings
  in
  { Omd.default_printer with heading = print_heading; finish = finish_print }

let omd input output =
  let output = open_out_bin output in
  let process ic =
    let md = Omd.of_channel ic in
    output_string output (Omd.to_html ~printer md);
    flush output
  in
  let ic = open_in input in
  match process ic with
  | () -> close_in ic
  | exception e -> close_in_noerr ic; raise e
```

This is more a draft than a final work, so reviews would be really appreciated :)