### PR TITLE
Added implementation of inline tags and tag blocks

### DIFF
--- a/src/block.ml
+++ b/src/block.ml
@@ -103,7 +103,7 @@ module Pre = struct
         {blocks; next = Rindented_code [Sub.to_string s]}
     | Rempty, Llist_item (kind, indent, s) ->
         {blocks; next = Rlist (kind, Tight, false, indent, [], process empty s)}
-    | Rempty, (Lsetext_heading _ | Lparagraph) ->
+    | Rempty, (Lsetext_heading _ | Lparagraph | Lendtag) ->
         {blocks; next = Rparagraph [Sub.to_string s]}
     | Rparagraph _, Llist_item ((Ordered (1, _) | Unordered _), _, s1) when not (Parser.is_empty (Parser.P.of_string (Sub.to_string s1))) ->
         process {blocks = close {blocks; next}; next = Rempty} s
@@ -125,7 +125,7 @@ module Pre = struct
             s
         in
         {blocks; next = Rfenced_code (ind, num, q, info, Sub.to_string s :: lines, a)}
-    | Rtag (tag, state, attributes), Ltag ("", _) ->
+    | Rtag (tag, state, attributes), Lendtag ->
         {blocks = Tag_block {tag; content = finish state; attributes} :: blocks; next = Rempty}
     | Rtag (tag, state, attributes), _ ->
         {blocks; next = Rtag (tag, process state s, attributes)}

--- a/src/markdown.ml
+++ b/src/markdown.ml
@@ -126,3 +126,6 @@ let rec inline b = function
               Buffer.nth b (Buffer.length b - 2) = '\n'))
       then
         Buffer.add_string b "\n"
+  | Tag {tag; content; attributes} ->
+      Printf.bprintf b "{!%s:%a}" tag inline content;
+      print_attributes b attributes

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -11,6 +11,7 @@ type printer = Html.printer =
     thematic_break: printer -> Buffer.t                              -> unit;
     html_block: printer     -> Buffer.t -> string                    -> unit;
     heading: printer        -> Buffer.t -> inline Heading.t          -> unit;
+    tag_block: printer      -> Buffer.t -> inline block Tag_block.t  -> unit;
     inline: printer         -> Buffer.t -> inline                    -> unit;
     concat: printer         -> Buffer.t -> inline list               -> unit;
     text: printer           -> Buffer.t -> string                    -> unit;
@@ -21,6 +22,7 @@ type printer = Html.printer =
     html: printer           -> Buffer.t -> string                    -> unit;
     link: printer           -> Buffer.t -> inline Link.t             -> unit;
     ref: printer            -> Buffer.t -> inline Ref.t              -> unit;
+    tag: printer            -> Buffer.t -> inline Tag.t              -> unit;
   }
 
 type t = inline block list

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -3,6 +3,7 @@ include Ast
 type printer = Html.printer =
   {
     document: printer       -> Buffer.t -> inline block list         -> unit;
+    attributes: printer     -> Buffer.t -> Attributes.t              -> unit;
     block: printer          -> Buffer.t -> inline block              -> unit;
     paragraph: printer      -> Buffer.t -> inline                    -> unit;
     blockquote: printer     -> Buffer.t -> inline block list         -> unit;

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -6,6 +6,7 @@ module Link_def = Ast.Link_def
 module Block_list = Ast.Block_list
 module Code_block = Ast.Code_block
 module Heading = Ast.Heading
+module Tag_block = Ast.Tag_block
 
 type 'a block = 'a Ast.block =
   | Paragraph of 'a
@@ -16,11 +17,13 @@ type 'a block = 'a Ast.block =
   | Code_block of Code_block.t
   | Html_block of string
   | Link_def of string Link_def.t
+  | Tag_block of 'a block Tag_block.t
 
 module Emph = Ast.Emph
 module Code = Ast.Code
 module Link = Ast.Link
 module Ref = Ast.Ref
+module Tag = Ast.Tag
 
 type inline = Ast.inline =
   | Concat of inline list
@@ -32,6 +35,7 @@ type inline = Ast.inline =
   | Link of inline Link.t
   | Ref of inline Ref.t
   | Html of string
+  | Tag of inline Tag.t
 
 type t = inline block list
 (** A markdown document *)
@@ -47,6 +51,7 @@ type printer = Html.printer =
     thematic_break: printer -> Buffer.t                              -> unit;
     html_block: printer     -> Buffer.t -> string                    -> unit;
     heading: printer        -> Buffer.t -> inline Heading.t          -> unit;
+    tag_block: printer      -> Buffer.t -> inline block Tag_block.t  -> unit;
     inline: printer         -> Buffer.t -> inline                    -> unit;
     concat: printer         -> Buffer.t -> inline list               -> unit;
     text: printer           -> Buffer.t -> string                    -> unit;
@@ -57,6 +62,7 @@ type printer = Html.printer =
     html: printer           -> Buffer.t -> string                    -> unit;
     link: printer           -> Buffer.t -> inline Link.t             -> unit;
     ref: printer            -> Buffer.t -> inline Ref.t              -> unit;
+    tag: printer            -> Buffer.t -> inline Tag.t              -> unit;
   }
 
 val of_channel: in_channel -> t

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -43,6 +43,7 @@ type t = inline block list
 type printer = Html.printer =
   {
     document: printer       -> Buffer.t -> inline block list         -> unit;
+    attributes: printer     -> Buffer.t -> Attributes.t              -> unit;
     block: printer          -> Buffer.t -> inline block              -> unit;
     paragraph: printer      -> Buffer.t -> inline                    -> unit;
     blockquote: printer     -> Buffer.t -> inline block list         -> unit;

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -271,6 +271,7 @@ type t =
   | Llist_item of Block_list.kind * int * Sub.t
   | Lparagraph
   | Ltag of string * Attributes.t
+  | Lendtag
 
 let sp3 s =
   match Sub.head s with
@@ -783,7 +784,7 @@ let tag s =
                   s, Attributes.empty
             in
             let string_tag = Buffer.contents tag in
-            let string_tag = if string_tag = "" then "none" else string_tag in
+            let string_tag = if string_tag = "" then raise Fail else string_tag in
             Ltag (string_tag, a)
         | Some (' ' | '\t' | '\010'..'\013') | None ->
             raise Fail
@@ -827,7 +828,7 @@ let parse s0 =
   | Some '{' ->
       tag s
   | Some '}' ->
-      Ltag ("", Attributes.empty)
+      Lendtag
   | Some _ ->
       (blank ||| indented_code ind) s
   | None ->

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -393,7 +393,7 @@ let attribute_string s =
               | None ->
                   Sub.of_string (Buffer.contents buf), Some (Buffer.contents buf')
               end
-          | None ->
+          | None | Some '!' ->
               Buffer.add_char buf '{';
               Buffer.add_buffer buf buf';
               Sub.of_string (Buffer.contents buf), None
@@ -863,7 +863,7 @@ let inline_attribute_string s =
           | Some '}' ->
               junk s;
               Some (Buffer.contents buf)
-          | None | Some '{' ->
+          | None | Some '{' | Some '!' ->
               set_pos s pos; None
           | Some c ->
               Buffer.add_char buf c;

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -270,8 +270,7 @@ type t =
   | Lhtml of bool * html_kind
   | Llist_item of Block_list.kind * int * Sub.t
   | Lparagraph
-  | Ltag of string * Attributes.t
-  | Lendtag
+  | Ltag of int * int * string * Attributes.t
 
 let sp3 s =
   match Sub.head s with
@@ -394,7 +393,7 @@ let attribute_string s =
               | None ->
                   Sub.of_string (Buffer.contents buf), Some (Buffer.contents buf')
               end
-          | None | Some '!' ->
+          | None ->
               Buffer.add_char buf '{';
               Buffer.add_buffer buf buf';
               Sub.of_string (Buffer.contents buf), None
@@ -769,31 +768,40 @@ let blank s =
   if not (is_empty s) then raise Fail;
   Lempty
 
-let tag s =
-  match Sub.heads 2 s with
-  | ['{'; '!'] ->
-      let tag = Buffer.create 17 in
-      let rec loop s =
+let tag_string s =
+  let buf = Buffer.create 17 in
+  let s, a =
+    match Sub.head ~rev:() s with
+    | Some '}' ->
+        attribute_string s
+    | _ ->
+        s, Attributes.empty
+  in
+  let s = ws ~rev:() (ws s) in
+  let rec loop s =
+    match Sub.head s with
+    | Some (' ' | '\t' | '\010'..'\013') | None ->
+        Buffer.contents buf, a
+    | Some c ->
+        Buffer.add_char buf c;
+        loop (Sub.tail s)
+  in
+  loop (ws s)
+
+let tag ind s =
+  match Sub.head s with
+  | Some '+' ->
+      let rec loop n s =
         match Sub.head s with
-        | Some ':' ->
-            let _, a =
-              match Sub.head ~rev:() s with
-              | Some '}' ->
-                  attribute_string s
-              | _ ->
-                  s, Attributes.empty
-            in
-            let string_tag = Buffer.contents tag in
-            let string_tag = if string_tag = "" then raise Fail else string_tag in
-            Ltag (string_tag, a)
-        | Some (' ' | '\t' | '\010'..'\013') | None ->
-            raise Fail
-        | Some c ->
-            Buffer.add_char tag c;
-            loop (Sub.tail s)
+        | Some '+' ->
+            loop (succ n) (Sub.tail s)
+        | Some _ | None ->
+            if n < 3 then raise Fail;
+            let s, a = tag_string s in
+            Ltag (ind, n, s, a)
       in
-      loop (Sub.tails 2 s)
-  | _ ->
+      loop 1 (Sub.tail s)
+  | Some _ | None ->
       raise Fail
 
 let indented_code ind s =
@@ -822,13 +830,9 @@ let parse s0 =
   | Some '*' ->
       (thematic_break ||| unordered_list_item ind) s
   | Some '+' ->
-      unordered_list_item ind s
+      (tag ind ||| unordered_list_item ind) s
   | Some ('0'..'9') ->
       ordered_list_item ind s
-  | Some '{' ->
-      tag s
-  | Some '}' ->
-      Lendtag
   | Some _ ->
       (blank ||| indented_code ind) s
   | None ->
@@ -864,7 +868,7 @@ let inline_attribute_string s =
           | Some '}' ->
               junk s;
               Some (Buffer.contents buf)
-          | None | Some '{' | Some '!' ->
+          | None | Some '{' ->
               set_pos s pos; None
           | Some c ->
               Buffer.add_char buf c;
@@ -1688,66 +1692,54 @@ let rec inline defs st =
               Buffer.add_string buf (String.make n '`'); loop acc st
         in
         loop2 0
-    | '{' ->
-        junk st;
-        begin
+    | '+' ->
+        let pos = pos st in
+        let rec loop2 n =
           match peek st with
-          | Some '!' ->
-              junk st;
+          | Some '+' ->
+              junk st; loop2 (succ n)
+          | Some _ ->
               let acc = text acc in
               let tag = Buffer.create 17 in
-              let rec loop2 () =
+              let contents = Buffer.create 17 in
+              let rec loop3 start seen_ws end_tag m bufcode =
                 match peek st with
-                | Some ':' ->
-                    junk st;
-                    let content = Buffer.create 17 in
-                    let rec loop3 start =
-                      match peek st with
-                      | Some (' ' | '\t' | '\010'..'\013' as c) ->
-                          junk st;
-                          if start then
-                            Buffer.add_char content c;
-                          loop3 start
-                      | Some '\\' ->
-                          junk st;
-                          begin
-                            match peek st with
-                            | Some '}' ->
-                                junk st;
-                                Buffer.add_char content '}';
-                                loop3 true
-                            | _ ->
-                                Buffer.add_char content '\\';
-                                loop3 true
-                          end
-                      | Some '}' ->
-                          junk st;
-                          loop (Pre.R (Tag {tag=Buffer.contents tag; content=inline defs (Buffer.contents content |> of_string); attributes=inline_attribute_string st}) :: acc) st
-                      | Some c ->
-                          junk st;
-                          Buffer.add_char content c;
-                          loop3 true
-                      | None ->
-                          Buffer.add_string buf "{!";
-                          Buffer.add_buffer buf tag;
-                          Buffer.add_char buf ':';
-                          Buffer.add_buffer buf content;
-                          loop acc st
-                    in loop3 false
-                | Some (' ' | '\t' | '\010'..'\013') | None ->
-                    Buffer.add_string buf "{!";
-                    Buffer.add_buffer buf tag;
-                    loop acc st
+                | Some '+' ->
+                    junk st; loop3 start seen_ws end_tag (succ m) bufcode
+                | Some (' ' | '\t' | '\010'..'\013') ->
+                    if m = n then
+                      loop (Pre.R (Tag {tag=Buffer.contents tag; content=inline defs (Buffer.contents contents |> of_string); attributes=inline_attribute_string st}) :: acc) st
+                    else begin
+                      if m > 0 then begin
+                        if not start && seen_ws && end_tag then Buffer.add_char bufcode ' ';
+                        Buffer.add_string bufcode (String.make m '+');
+                      end;
+                      junk st; loop3 (start && m = 0) end_tag true 0 contents
+                    end
                 | Some c ->
-                    junk st;
-                    Buffer.add_char tag c;
-                    loop2 ()
+                    if m = n then
+                      loop (Pre.R (Tag {tag=Buffer.contents tag; content=inline defs (Buffer.contents contents |> of_string); attributes=inline_attribute_string st}) :: acc) st
+                    else begin
+                      junk st;
+                      if not start && seen_ws && end_tag then Buffer.add_char bufcode ' ';
+                      if m > 0 then Buffer.add_string bufcode (String.make m '+');
+                      Buffer.add_char bufcode c;
+                      loop3 false false end_tag 0 bufcode
+                    end
+                | None ->
+                    if m = n then
+                      loop (Pre.R (Tag {tag=Buffer.contents tag; content=inline defs (Buffer.contents contents |> of_string); attributes=inline_attribute_string st}) :: acc) st
+                    else begin
+                      Buffer.add_string buf (range st pos n);
+                      set_pos st (pos + n);
+                      loop acc st
+                    end
               in
-              loop2 ()
-          | _ ->
-              Buffer.add_char buf '{';
-              loop acc st
-        end
+              loop3 true false false 0 tag
+          | None ->
+              Buffer.add_string buf (String.make n '+'); loop acc st
+        in
+        loop2 0
     | '\\' as c ->
         junk st;
         begin match peek st with

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -34,6 +34,8 @@ and inline = function
       Atom "img"
   | Ref {kind = Img; label; def; _} ->
       List [Atom "img-ref"; inline label; link_def atom def]
+  | Tag {tag; content; _} ->
+      List [Atom "tag"; Atom tag; inline content]
 
 let rec block = function
   | Paragraph x ->
@@ -44,8 +46,8 @@ let rec block = function
       List (Atom "blockquote" :: List.map block xs)
   | Thematic_break ->
       Atom "thematic-break"
-  | Heading h ->
-      List [Atom "heading"; Atom (string_of_int h.level); inline h.text]
+  | Heading {level; text; _} ->
+      List [Atom "heading"; Atom (string_of_int level); inline text]
   | Code_block {kind = None; code = Some s; _} ->
       List [Atom "indented-code"; Atom s]
   | Code_block {kind = None; code = None; _} ->
@@ -58,6 +60,8 @@ let rec block = function
       List [Atom "html"; Atom s]
   | Link_def {label; destination; _} ->
       List [Atom "link-def"; Atom label; Atom destination]
+  | Tag_block {tag; content; _} ->
+      List [Atom "tag"; Atom tag; List (Atom "list-item" :: List.map block content)]
 
 let create ast =
   List (List.map block ast)

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -61,7 +61,7 @@ let rec block = function
   | Link_def {label; destination; _} ->
       List [Atom "link-def"; Atom label; Atom destination]
   | Tag_block {tag; content; _} ->
-      List [Atom "tag"; Atom tag; List (Atom "list-item" :: List.map block content)]
+      List [Atom "tag"; Atom tag; List (List.map block content)]
 
 let create ast =
   List (List.map block ast)

--- a/src/text.ml
+++ b/src/text.ml
@@ -18,6 +18,8 @@ let rec inline b = function
       inline b l.def.label
   | Ref r ->
       inline b r.label
+  | Tag t ->
+      inline b t.content
 
 let block f b = function
   | Paragraph x ->

--- a/tests/tag/dune
+++ b/tests/tag/dune
@@ -1,0 +1,27 @@
+(rule
+ (targets tag.html.out)
+ (deps tag.md)
+ (action (with-stdout-to %{targets} (run omd %{deps}))))
+
+(alias
+ (name tag)
+ (action (diff tag.html tag.html.out)))
+
+(executable
+ (name uppercase)
+ (public_name omd_uppercase)
+ (libraries omd))
+
+(rule
+ (targets tag_uppercase.html.out)
+ (deps tag_uppercase.md)
+ (action (with-stdout-to %{targets} (run omd_uppercase %{deps}))))
+
+(alias
+ (name tag_uppercase)
+ (action (diff tag_uppercase.html tag_uppercase.html.out)))
+
+(alias
+ (name runtest)
+ (deps (alias tag)
+       (alias tag_uppercase)))

--- a/tests/tag/tag.html
+++ b/tests/tag/tag.html
@@ -1,0 +1,3 @@
+<p>This is an inline extension which wont do anything but what did you expect, we did not change the Tag printer.</p>
+<p>Let's have a block now:</p>
+<p>Kinda useless for now</p>

--- a/tests/tag/tag.md
+++ b/tests/tag/tag.md
@@ -1,0 +1,7 @@
+This is an inline extension {!foo: which wont do anything} but what did you expect, we did not change the Tag printer.
+
+Let's have a block now:
+
+{!bar:
+  Kinda useless for now
+}

--- a/tests/tag/tag.md
+++ b/tests/tag/tag.md
@@ -1,7 +1,7 @@
-This is an inline extension {!foo: which wont do anything} but what did you expect, we did not change the Tag printer.
+This is an inline extension +foo which wont do anything+ but what did you expect, we did not change the Tag printer.
 
 Let's have a block now:
 
-{!bar:
++++bar
   Kinda useless for now
-}
++++

--- a/tests/tag/tag_uppercase.html
+++ b/tests/tag/tag_uppercase.html
@@ -1,0 +1,3 @@
+<p>This extension is called I'M NOT YELLING I SWEAR. It's kind of a loud one</p>
+<p>It makes blocks really annoying too:</p>
+<p>BUT I DONT UNDERSTAND WHY :'(</p>

--- a/tests/tag/tag_uppercase.md
+++ b/tests/tag/tag_uppercase.md
@@ -1,0 +1,7 @@
+This extension is called {!capitalize: i'm not yelling I swear}. It's kind of a loud one
+
+It makes blocks really annoying too:
+
+{!capitalize:
+  But I dont understand why :'(
+}

--- a/tests/tag/tag_uppercase.md
+++ b/tests/tag/tag_uppercase.md
@@ -1,7 +1,7 @@
-This extension is called {!capitalize: i'm not yelling I swear}. It's kind of a loud one
+This extension is called +capitalize i'm not yelling I swear+. It's kind of a loud one
 
 It makes blocks really annoying too:
 
-{!capitalize:
++++capitalize
   But I dont understand why :'(
-}
++++

--- a/tests/tag/uppercase.ml
+++ b/tests/tag/uppercase.ml
@@ -33,32 +33,32 @@ let main () =
   Arg.parse (Arg.align spec) (fun s -> input := s :: !input) "omd [options] [inputfile1 .. inputfileN] [options]";
   let output = if !output = "" then stdout else open_out_bin !output in
   let printer =
-    let print_upper_text p b t =
+    let text p b t =
       let t = String.uppercase_ascii t in
       Omd.default_printer.text p b t
     in
-    let print_upper_code p b (c: Omd.Code.t) =
+    let code p b (c: Omd.Code.t) =
       let c = {c with content = String.uppercase_ascii c.content} in
       Omd.default_printer.code p b c
     in
-    let print_tag (p: Omd.printer) b (t: 'inline Omd.Tag.t) =
+    let tag (p: Omd.printer) b (t: 'inline Omd.Tag.t) =
       match t.tag with
       | "capitalize" ->
-        p.inline {p with text = print_upper_text; code = print_upper_code} b t.content
+        p.inline {p with text; code} b t.content
       | _ -> Omd.default_printer.tag p b t
     in
-    let print_tag_block (p: Omd.printer) b t =
+    let tag_block (p: Omd.printer) b t =
       match t.Omd.Tag_block.tag with
       | "capitalize" ->
         let f i block =
-          p.block {p with text = print_upper_text; code = print_upper_code} b block;
+          p.block {p with text; code} b block;
           if i < List.length t.content - 1 then
             Buffer.add_char b '\n'
         in
         List.iteri f t.content
       | _ -> Omd.default_printer.tag_block p b t
     in
-    {Omd.default_printer with tag = print_tag; tag_block = print_tag_block}
+    {Omd.default_printer with tag; tag_block}
   in
   let process ic =
     let md = Omd.of_channel ic in

--- a/tests/tag/uppercase.ml
+++ b/tests/tag/uppercase.ml
@@ -1,0 +1,88 @@
+type format =
+  | Sexp
+  | Html
+  | Markdown
+  | Text
+
+let fmt = ref Html
+
+let convert ast =
+  match !fmt with
+  | Html -> Omd.to_html ast
+  | Sexp -> Omd.to_sexp ast
+  | Markdown | Text -> assert false
+
+let main () =
+  let input = ref [] in
+  let output = ref "" in
+  let spec =
+    let open Arg in
+    [
+      "-o", Set_string output,
+      " file.html Specify the output file (default is stdout).";
+
+      "-sexp", Unit (fun () -> fmt := Sexp), " sexp";
+
+      "--", Rest(fun s -> input := s :: !input),
+      " Consider all remaining arguments as input file names.";
+
+      "-version", Unit(fun () -> print_endline "This is version VERSION."; exit 0),
+      " Print version.";
+    ]
+  in
+  Arg.parse (Arg.align spec) (fun s -> input := s :: !input) "omd [options] [inputfile1 .. inputfileN] [options]";
+  let output = if !output = "" then stdout else open_out_bin !output in
+  let printer =
+    let print_upper_text p b t =
+      let t = String.uppercase_ascii t in
+      Omd.default_printer.text p b t
+    in
+    let print_upper_code p b (c: Omd.Code.t) =
+      let c = {c with content = String.uppercase_ascii c.content} in
+      Omd.default_printer.code p b c
+    in
+    let print_tag (p: Omd.printer) b (t: 'inline Omd.Tag.t) =
+      match t.tag with
+      | "capitalize" ->
+        p.inline {p with text = print_upper_text; code = print_upper_code} b t.content
+      | _ -> Omd.default_printer.tag p b t
+    in
+    let print_tag_block (p: Omd.printer) b t =
+      match t.Omd.Tag_block.tag with
+      | "capitalize" ->
+        let f i block =
+          p.block {p with text = print_upper_text; code = print_upper_code} b block;
+          if i < List.length t.content - 1 then
+            Buffer.add_char b '\n'
+        in
+        List.iteri f t.content
+      | _ -> Omd.default_printer.tag_block p b t
+    in
+    {Omd.default_printer with tag = print_tag; tag_block = print_tag_block}
+  in
+  let process ic =
+    let md = Omd.of_channel ic in
+    output_string output (Omd.to_html ~printer md);
+    flush output
+  in
+  if !input = [] then
+    process stdin
+  else
+    List.iter (fun filename ->
+        let ic = open_in filename in
+        match process ic with
+        | () -> close_in ic
+        | exception e -> close_in_noerr ic; raise e
+      ) !input
+
+let () =
+  try
+    main ()
+  with
+  | Sys_error msg ->
+      Printf.eprintf "Error: %s\n" msg;
+      exit 1
+  | exn ->
+      Printf.eprintf "Error: %s\n" (Printexc.to_string exn);
+      Printexc.print_backtrace stderr;
+      exit 1


### PR DESCRIPTION
This pull request contains the implementation of the tag extension system discussed [here](https://github.com/ocaml/omd/issues/190):

It allows the user to use self defined printers by using a new syntax:
For inline tags:
```
  This is an {!foo: inline tag}.
```
For tag blocks:
```
{!bar:
  This is a tag block
}
```

The html tag printers will be called with an object containing:
- the string of the tag (in the examples, it will be `bar`)
- in the case of an inline tag, the text (`inline tag` for the example)
- in the case of a tag block, the list of the blocks contained in the tag (here, a Paragraph).
- and finally the attributes

Nesting blocks inside a tag block is possible !

This implementation may need some corrections, I'm listening to all your comments and modifications requests :)