### PR TITLE
Implementation of definition lists

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -62,6 +62,14 @@ module Heading = struct
     }
 end
 
+module Def_list = struct
+  type 'a elt = { term : 'a; defs : 'a list }
+  type 'a t =
+  {
+    content: 'a elt list
+  }
+end
+
 module Tag_block = struct
   type 'block t =
   {
@@ -80,6 +88,7 @@ type 'a block =
   | Code_block of Code_block.t
   | Html_block of string
   | Link_def of string Link_def.t
+  | Def_list of 'a Def_list.t
   | Tag_block of 'a block Tag_block.t
 
 module Emph = struct
@@ -160,6 +169,7 @@ let rec map f = function
   | Blockquote xs -> Blockquote (List.map (map f) xs)
   | Thematic_break -> Thematic_break
   | Heading h -> Heading {h with text = f h.text}
+  | Def_list l -> Def_list {content = List.map (fun elt -> {Def_list.term = f elt.Def_list.term; defs = List.map f elt.defs}) l.content}
   | Tag_block t -> Tag_block {t with content = List.map (map f) t.content}
   | Code_block _ | Html_block _ | Link_def _ as x -> x
 
@@ -168,7 +178,7 @@ let defs ast =
     | List l -> List.fold_left (List.fold_left loop) acc l.blocks
     | Blockquote l | Tag_block {content = l; _} -> List.fold_left loop acc l
     | Paragraph _ | Thematic_break | Heading _
-    | Code_block _ | Html_block _ -> acc
+    | Def_list _ | Code_block _ | Html_block _ -> acc
     | Link_def def -> def :: acc
   in
   List.rev (List.fold_left loop [] ast)

--- a/src/html.ml
+++ b/src/html.ml
@@ -12,6 +12,7 @@ type printer =
     thematic_break: printer -> Buffer.t                              -> unit;
     html_block: printer     -> Buffer.t -> string                    -> unit;
     heading: printer        -> Buffer.t -> inline Heading.t          -> unit;
+    def_list: printer       -> Buffer.t -> inline Def_list.t         -> unit;
     tag_block: printer      -> Buffer.t -> inline block Tag_block.t  -> unit;
     inline: printer         -> Buffer.t -> inline                    -> unit;
     concat: printer         -> Buffer.t -> inline list               -> unit;
@@ -266,6 +267,20 @@ let heading p b h =
   p.inline p b h.text;
   Buffer.add_string b (Printf.sprintf "</h%d>" h.level)
 
+let def_list p b l =
+  Buffer.add_string b (Printf.sprintf "<dl>\n");
+  List.iter (fun {Def_list.term; defs} ->
+    Buffer.add_string b (Printf.sprintf "<dt>");
+    p.inline p b term;
+    Buffer.add_string b (Printf.sprintf "</dt>\n");
+    List.iter (fun s ->
+      Buffer.add_string b (Printf.sprintf "<dd>");
+      p.inline p b s;
+      Buffer.add_string b (Printf.sprintf "</dd>\n")
+    ) defs;
+  ) l.Def_list.content;
+  Buffer.add_string b (Printf.sprintf "</dl>")
+
 let tag_block p b t =
   let f i block =
     p.block p b block;
@@ -289,6 +304,8 @@ let block p b = function
       p.html_block p b body
   | Heading h ->
       p.heading p b h
+  | Def_list l ->
+      p.def_list p b l
   | Tag_block t ->
       p.tag_block p b t
   | Link_def _ ->
@@ -306,6 +323,7 @@ let default_printer =
     thematic_break;
     html_block;
     heading;
+    def_list;
     tag_block;
     inline;
     concat;

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -12,6 +12,7 @@ type printer = Html.printer =
     thematic_break: printer -> Buffer.t                              -> unit;
     html_block: printer     -> Buffer.t -> string                    -> unit;
     heading: printer        -> Buffer.t -> inline Heading.t          -> unit;
+    def_list: printer       -> Buffer.t -> inline Def_list.t         -> unit;
     tag_block: printer      -> Buffer.t -> inline block Tag_block.t  -> unit;
     inline: printer         -> Buffer.t -> inline                    -> unit;
     concat: printer         -> Buffer.t -> inline list               -> unit;

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -6,6 +6,7 @@ module Link_def = Ast.Link_def
 module Block_list = Ast.Block_list
 module Code_block = Ast.Code_block
 module Heading = Ast.Heading
+module Def_list = Ast.Def_list
 module Tag_block = Ast.Tag_block
 
 type 'a block = 'a Ast.block =
@@ -17,6 +18,7 @@ type 'a block = 'a Ast.block =
   | Code_block of Code_block.t
   | Html_block of string
   | Link_def of string Link_def.t
+  | Def_list of 'a Def_list.t
   | Tag_block of 'a block Tag_block.t
 
 module Emph = Ast.Emph
@@ -52,6 +54,7 @@ type printer = Html.printer =
     thematic_break: printer -> Buffer.t                              -> unit;
     html_block: printer     -> Buffer.t -> string                    -> unit;
     heading: printer        -> Buffer.t -> inline Heading.t          -> unit;
+    def_list: printer       -> Buffer.t -> inline Def_list.t         -> unit;
     tag_block: printer      -> Buffer.t -> inline block Tag_block.t  -> unit;
     inline: printer         -> Buffer.t -> inline                    -> unit;
     concat: printer         -> Buffer.t -> inline list               -> unit;

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -270,6 +270,7 @@ type t =
   | Lhtml of bool * html_kind
   | Llist_item of Block_list.kind * int * Sub.t
   | Lparagraph
+  | Ldef_list of string
   | Ltag of int * int * string * Attributes.t
 
 let sp3 s =
@@ -788,6 +789,12 @@ let tag_string s =
   in
   loop (ws s)
 
+let def_list s =
+  let s = Sub.tail s in
+  match Sub.head (s) with
+  | Some (' ' | '\t' | '\010'..'\013') -> Ldef_list (String.trim (Sub.to_string s))
+  | _ -> raise Fail
+
 let tag ind s =
   match Sub.head s with
   | Some '+' ->
@@ -833,6 +840,8 @@ let parse s0 =
       (tag ind ||| unordered_list_item ind) s
   | Some ('0'..'9') ->
       ordered_list_item ind s
+  | Some ':' ->
+      def_list s
   | Some _ ->
       (blank ||| indented_code ind) s
   | None ->

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -60,6 +60,8 @@ let rec block = function
       List [Atom "html"; Atom s]
   | Link_def {label; destination; _} ->
       List [Atom "link-def"; Atom label; Atom destination]
+  | Def_list {content} ->
+      List [Atom "def-list"; List (List.map (fun elt -> List [inline elt.Def_list.term; List (List.map inline elt.defs)]) content)]
   | Tag_block {tag; content; _} ->
       List [Atom "tag"; Atom tag; List (List.map block content)]
 

--- a/tests/def_list/def_list.html
+++ b/tests/def_list/def_list.html
@@ -1,0 +1,8 @@
+<dl>
+<dt>First Term</dt>
+<dd>This is the definition of the first term.</dd>
+<dt>Second Term</dt>
+<dd>This is one definition of the second term.</dd>
+<dd>This is another definition of the second term.</dd>
+</dl>
+<p>: This is not a correct definition list</p>

--- a/tests/def_list/def_list.html
+++ b/tests/def_list/def_list.html
@@ -3,6 +3,7 @@
 <dd>This is the definition of the first term.</dd>
 <dt>Second Term</dt>
 <dd>This is one definition of the second term.</dd>
-<dd>This is another definition of the second term.</dd>
+<dd>This is another definition of the second term.
+which is multiline</dd>
 </dl>
 <p>: This is not a correct definition list</p>

--- a/tests/def_list/def_list.md
+++ b/tests/def_list/def_list.md
@@ -1,0 +1,8 @@
+First Term
+: This is the definition of the first term.
+
+Second Term
+: This is one definition of the second term.
+: This is another definition of the second term.
+
+: This is not a correct definition list

--- a/tests/def_list/def_list.md
+++ b/tests/def_list/def_list.md
@@ -4,5 +4,6 @@ First Term
 Second Term
 : This is one definition of the second term.
 : This is another definition of the second term.
+which is multiline
 
 : This is not a correct definition list

--- a/tests/def_list/dune
+++ b/tests/def_list/dune
@@ -1,0 +1,12 @@
+(rule
+ (targets def_list.html.out)
+ (deps def_list.md)
+ (action (with-stdout-to %{targets} (run omd %{deps}))))
+
+(alias
+ (name def_list)
+ (action (diff def_list.html def_list.html.out)))
+
+(alias
+ (name runtest)
+ (deps (alias def_list)))


### PR DESCRIPTION
This pull request adds the implementation of definition lists in markdown files.
This feature is not part of the commonmark specification, but was requested in [this issue](https://github.com/ocaml/omd/issues/188) as being a part of the [extended markdown syntax](https://www.markdownguide.org/extended-syntax).

The syntax of definition lists is pretty easy:
```
First Term
: This is the definition of the first term.

Second Term
: This is one definition of the second term.
: This is another definition of the second term.
```

The parsing is dumb, but works actually pretty well:
Lines of raw text beginning are considered as `Ldef_list` tokens, and if during the process of the blocks, they are preceded by one single line of raw text or an already created definition list block, a definition list block is created (or fed with the new line).