### PR TITLE
Iterator and Mapper on the Ast

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -182,3 +182,228 @@ let defs ast =
     | Link_def def -> def :: acc
   in
   List.rev (List.fold_left loop [] ast)
+
+module Mapper =
+struct
+  type t =
+    { document:       t -> inline block list         -> inline block list
+    ; blocks:         t -> inline block list         -> inline block list
+    ; attributes:     t -> Attributes.t              -> Attributes.t
+    ; block:          t -> inline block              -> inline block
+    ; paragraph:      t -> inline                    -> inline
+    ; blockquote:     t -> inline block list         -> inline block list
+    ; list:           t -> inline block Block_list.t -> inline block Block_list.t
+    ; list_item:      t -> inline block list         -> inline block list
+    ; code_block:     t -> Code_block.t              -> Code_block.t
+    ; thematic_break: t -> unit                      -> unit
+    ; html_block:     t -> string                    -> string
+    ; heading:        t -> inline Heading.t          -> inline Heading.t
+    ; def_list:       t -> inline Def_list.t         -> inline Def_list.t
+    ; tag_block:      t -> inline block Tag_block.t  -> inline block Tag_block.t
+    ; inline:         t -> inline                    -> inline
+    ; concat:         t -> inline list               -> inline list
+    ; text:           t -> string                    -> string
+    ; emph:           t -> inline Emph.t             -> inline Emph.t
+    ; code:           t -> Code.t                    -> Code.t
+    ; hard_break:     t -> unit                      -> unit
+    ; soft_break:     t -> unit                      -> unit
+    ; html:           t -> string                    -> string
+    ; link:           t -> inline Link.t             -> inline Link.t
+    ; ref:            t -> inline Ref.t              -> inline Ref.t
+    ; tag:            t -> inline Tag.t              -> inline Tag.t
+    }
+
+  let default : t =
+    let identity = (fun _m x -> x) in
+    let link_def (r :t) (d :_ Link_def.t) =
+      { d with attributes = r.attributes r d.attributes }
+    in
+    {
+      document = (fun r l -> r.blocks r l);
+      blocks = (fun r l -> List.map (r.block r) l);
+      list_item = (fun r li -> r.blocks r li);
+      attributes = identity;
+      block = begin fun r -> function
+        | Paragraph i -> Paragraph (r.paragraph r i)
+        | List list -> List (r.list r list)
+        | Blockquote blocks -> Blockquote (r.blockquote r blocks)
+        | Thematic_break -> r.thematic_break r (); Thematic_break
+        | Heading h -> Heading (r.heading r h)
+        | Code_block c -> Code_block (r.code_block r c)
+        | Html_block h -> Html_block (r.html_block r h)
+        | Link_def d -> Link_def (link_def r d)
+        | Def_list d -> Def_list (r.def_list r d)
+        | Tag_block t -> Tag_block (r.tag_block r t)
+      end;
+      paragraph = (fun r p -> r.inline r p);
+      blockquote = (fun r blocks -> r.blocks r blocks);
+      list = begin fun r l ->
+        { l with blocks = List.map (r.blocks r) l.blocks }
+      end;
+      code_block = (fun r c -> {c with attributes = r.attributes r c.attributes});
+      thematic_break = identity;
+      html_block = identity;
+      heading = begin fun r h ->
+        { h with
+          text = r.inline r h.text
+        ; attributes = r.attributes r h.attributes}
+      end;
+      def_list = begin fun r {content} ->
+        let open Def_list in
+        { content =
+            List.map
+              begin fun { term; defs } ->
+                { term = r.inline r term
+                ; defs = List.map (r.inline r) defs }
+              end
+              content }
+      end;
+      tag_block = begin fun r t ->
+        { t with
+          attributes = r.attributes r t.attributes
+        ; content = r.blocks r t.content }
+      end;
+      inline = begin fun r -> function
+        | Concat il -> Concat (List.map (r.inline r) il)
+        | Text t -> Text (r.text r t)
+        | Emph e -> Emph (r.emph r e)
+        | Code c -> Code (r.code r c)
+        | Hard_break -> r.hard_break r (); Hard_break
+        | Soft_break -> r.soft_break r (); Soft_break
+        | Link l -> Link (r.link r l)
+        | Ref ref -> Ref (r.ref r ref)
+        | Html h -> Html (r.html r h)
+        | Tag t -> Tag (r.tag r t)
+      end;
+      concat = (fun r il -> List.map (r.inline r) il);
+      text = identity;
+      emph = begin fun r e ->
+        { e with content = r.inline r e.content }
+      end;
+      code = begin fun r c ->
+        { c with attributes = r.attributes r c.attributes }
+      end;
+      hard_break = identity;
+      soft_break = identity;
+      html = identity;
+      link = (fun r l -> { l with def = link_def r l.def });
+      ref = begin fun r ref ->
+        { ref with
+          label = r.inline r ref.label
+        ; def = link_def r ref.def }
+      end;
+      tag = begin fun r t ->
+        { t with
+          content = r.inline r t.content
+        ; attributes = r.attributes r t.attributes }
+      end;
+    }
+end
+
+module Iterator =
+struct
+  type 'a t =
+    { document:       'a t -> 'a -> inline block list         -> unit
+    ; blocks:         'a t -> 'a -> inline block list         -> unit
+    ; attributes:     'a t -> 'a -> Attributes.t              -> unit
+    ; block:          'a t -> 'a -> inline block              -> unit
+    ; paragraph:      'a t -> 'a -> inline                    -> unit
+    ; blockquote:     'a t -> 'a -> inline block list         -> unit
+    ; list:           'a t -> 'a -> inline block Block_list.t -> unit
+    ; list_item:      'a t -> 'a -> inline block list         -> unit
+    ; code_block:     'a t -> 'a -> Code_block.t              -> unit
+    ; thematic_break: 'a t -> 'a -> unit                      -> unit
+    ; html_block:     'a t -> 'a -> string                    -> unit
+    ; heading:        'a t -> 'a -> inline Heading.t          -> unit
+    ; def_list:       'a t -> 'a -> inline Def_list.t         -> unit
+    ; tag_block:      'a t -> 'a -> inline block Tag_block.t  -> unit
+    ; inline:         'a t -> 'a -> inline                    -> unit
+    ; concat:         'a t -> 'a -> inline list               -> unit
+    ; text:           'a t -> 'a -> string                    -> unit
+    ; emph:           'a t -> 'a -> inline Emph.t             -> unit
+    ; code:           'a t -> 'a -> Code.t                    -> unit
+    ; hard_break:     'a t -> 'a -> unit                      -> unit
+    ; soft_break:     'a t -> 'a -> unit                      -> unit
+    ; html:           'a t -> 'a -> string                    -> unit
+    ; link:           'a t -> 'a -> inline Link.t             -> unit
+    ; ref:            'a t -> 'a -> inline Ref.t              -> unit
+    ; tag:            'a t -> 'a -> inline Tag.t              -> unit
+    }
+
+  let default : 'a t =
+    let identity = (fun _ _ _ -> ()) in
+    let link_def (r :'a t) ctx (d :_ Link_def.t) =
+      r.attributes r ctx d.attributes
+    in
+    {
+      document = (fun r ctx l -> r.blocks r ctx l);
+      blocks = (fun r ctx l -> List.iter (r.block r ctx) l);
+      list_item = (fun r ctx li -> r.blocks r ctx li);
+      attributes = identity;
+      block = begin fun r ctx -> function
+        | Paragraph i -> (r.paragraph r ctx i)
+        | List list -> (r.list r ctx list)
+        | Blockquote blocks -> (r.blockquote r ctx blocks)
+        | Thematic_break -> r.thematic_break r ctx ()
+        | Heading h -> (r.heading r ctx h)
+        | Code_block c -> (r.code_block r ctx c)
+        | Html_block h -> (r.html_block r ctx h)
+        | Link_def d -> (link_def r ctx d)
+        | Def_list d -> (r.def_list r ctx d)
+        | Tag_block t -> (r.tag_block r ctx t)
+      end;
+      paragraph = (fun r ctx p -> r.inline r ctx p);
+      blockquote = (fun r ctx blocks -> r.blocks r ctx blocks);
+      list = begin fun r ctx l ->
+        List.iter (r.blocks r ctx) l.blocks
+      end;
+      code_block = (fun r ctx c -> r.attributes r ctx c.attributes);
+      thematic_break = identity;
+      html_block = identity;
+      heading = begin fun r ctx h ->
+        r.inline r ctx h.text;
+        r.attributes r ctx h.attributes
+      end;
+      def_list = begin fun r ctx {content} ->
+        let open Def_list in
+        List.iter
+          begin fun { term; defs } ->
+            r.inline r ctx term;
+            List.iter (r.inline r ctx) defs;
+          end
+          content
+      end;
+      tag_block = begin fun r ctx t ->
+        r.attributes r ctx t.attributes;
+        r.blocks r ctx t.content
+      end;
+      inline = begin fun r ctx -> function
+        | Concat il -> (List.iter (r.inline r ctx) il)
+        | Text t -> (r.text r ctx t)
+        | Emph e -> (r.emph r ctx e)
+        | Code c -> (r.code r ctx c)
+        | Hard_break -> r.hard_break r ctx ()
+        | Soft_break -> r.soft_break r ctx ()
+        | Link l -> (r.link r ctx l)
+        | Ref ref -> (r.ref r ctx ref)
+        | Html h -> (r.html r ctx h)
+        | Tag t -> (r.tag r ctx t)
+      end;
+      concat = (fun r ctx il -> List.iter (r.inline r ctx) il);
+      text = identity;
+      emph = (fun r ctx e -> r.inline r ctx e.content);
+      code = (fun r ctx c -> r.attributes r ctx c.attributes);
+      hard_break = identity;
+      soft_break = identity;
+      html = identity;
+      link = (fun r ctx l -> link_def r ctx l.def);
+      ref = begin fun r ctx ref ->
+        r.inline r ctx ref.label;
+        link_def r ctx ref.def
+      end;
+      tag = begin fun r ctx t ->
+        r.inline r ctx t.content;
+        r.attributes r ctx t.attributes
+      end;
+    }
+end

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -213,7 +213,7 @@ struct
     ; tag:            t -> inline Tag.t              -> inline Tag.t
     }
 
-  let default : t =
+  let map : t =
     let identity = (fun _m x -> x) in
     let link_def (r :t) (d :_ Link_def.t) =
       { d with attributes = r.attributes r d.attributes }
@@ -330,7 +330,7 @@ struct
     ; tag:            'a t -> 'a -> inline Tag.t              -> unit
     }
 
-  let default : 'a t =
+  let iter : 'a t =
     let identity = (fun _ _ _ -> ()) in
     let link_def (r :'a t) ctx (d :_ Link_def.t) =
       r.attributes r ctx d.attributes

--- a/src/html.ml
+++ b/src/html.ml
@@ -237,7 +237,7 @@ let tag_block p add t =
   List.iteri f t.Tag_block.content
 
 let default_printer =
-{ default with
+{ iter with
   document
 ; attributes
 ; paragraph

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -1,31 +1,6 @@
 include Ast
 
-type printer = Html.printer =
-  {
-    document: printer       -> Buffer.t -> inline block list         -> unit;
-    attributes: printer     -> Buffer.t -> Attributes.t              -> unit;
-    block: printer          -> Buffer.t -> inline block              -> unit;
-    paragraph: printer      -> Buffer.t -> inline                    -> unit;
-    blockquote: printer     -> Buffer.t -> inline block list         -> unit;
-    list: printer           -> Buffer.t -> inline block Block_list.t -> unit;
-    code_block: printer     -> Buffer.t -> Code_block.t              -> unit;
-    thematic_break: printer -> Buffer.t                              -> unit;
-    html_block: printer     -> Buffer.t -> string                    -> unit;
-    heading: printer        -> Buffer.t -> inline Heading.t          -> unit;
-    def_list: printer       -> Buffer.t -> inline Def_list.t         -> unit;
-    tag_block: printer      -> Buffer.t -> inline block Tag_block.t  -> unit;
-    inline: printer         -> Buffer.t -> inline                    -> unit;
-    concat: printer         -> Buffer.t -> inline list               -> unit;
-    text: printer           -> Buffer.t -> string                    -> unit;
-    emph: printer           -> Buffer.t -> inline Emph.t             -> unit;
-    code: printer           -> Buffer.t -> Code.t                    -> unit;
-    hard_break: printer     -> Buffer.t                              -> unit;
-    soft_break: printer     -> Buffer.t                              -> unit;
-    html: printer           -> Buffer.t -> string                    -> unit;
-    link: printer           -> Buffer.t -> inline Link.t             -> unit;
-    ref: printer            -> Buffer.t -> inline Ref.t              -> unit;
-    tag: printer            -> Buffer.t -> inline Tag.t              -> unit;
-  }
+type printer = (string -> unit) Iterator.t
 
 type t = inline block list
 

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -42,39 +42,14 @@ type inline = Ast.inline =
 type t = inline block list
 (** A markdown document *)
 
-type printer = Html.printer =
-  {
-    document: printer       -> Buffer.t -> inline block list         -> unit;
-    attributes: printer     -> Buffer.t -> Attributes.t              -> unit;
-    block: printer          -> Buffer.t -> inline block              -> unit;
-    paragraph: printer      -> Buffer.t -> inline                    -> unit;
-    blockquote: printer     -> Buffer.t -> inline block list         -> unit;
-    list: printer           -> Buffer.t -> inline block Block_list.t -> unit;
-    code_block: printer     -> Buffer.t -> Code_block.t              -> unit;
-    thematic_break: printer -> Buffer.t                              -> unit;
-    html_block: printer     -> Buffer.t -> string                    -> unit;
-    heading: printer        -> Buffer.t -> inline Heading.t          -> unit;
-    def_list: printer       -> Buffer.t -> inline Def_list.t         -> unit;
-    tag_block: printer      -> Buffer.t -> inline block Tag_block.t  -> unit;
-    inline: printer         -> Buffer.t -> inline                    -> unit;
-    concat: printer         -> Buffer.t -> inline list               -> unit;
-    text: printer           -> Buffer.t -> string                    -> unit;
-    emph: printer           -> Buffer.t -> inline Emph.t             -> unit;
-    code: printer           -> Buffer.t -> Code.t                    -> unit;
-    hard_break: printer     -> Buffer.t                              -> unit;
-    soft_break: printer     -> Buffer.t                              -> unit;
-    html: printer           -> Buffer.t -> string                    -> unit;
-    link: printer           -> Buffer.t -> inline Link.t             -> unit;
-    ref: printer            -> Buffer.t -> inline Ref.t              -> unit;
-    tag: printer            -> Buffer.t -> inline Tag.t              -> unit;
-  }
-
 val of_channel: in_channel -> t
 
 val of_string: string -> t
 
 module Mapper = Ast.Mapper
 module Iterator = Ast.Iterator
+
+type printer = (string -> unit) Iterator.t
 
 val default_printer: printer
 

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -73,6 +73,9 @@ val of_channel: in_channel -> t
 
 val of_string: string -> t
 
+module Mapper = Ast.Mapper
+module Iterator = Ast.Iterator
+
 val default_printer: printer
 
 val to_html: ?printer:printer -> t -> string

--- a/tests/tag/uppercase.ml
+++ b/tests/tag/uppercase.ml
@@ -33,30 +33,30 @@ let main () =
   Arg.parse (Arg.align spec) (fun s -> input := s :: !input) "omd [options] [inputfile1 .. inputfileN] [options]";
   let output = if !output = "" then stdout else open_out_bin !output in
   let printer =
-    let text p b t =
+    let text p add t =
       let t = String.uppercase_ascii t in
-      Omd.default_printer.text p b t
+      Omd.default_printer.text p add t
     in
-    let code p b (c: Omd.Code.t) =
+    let code p add (c: Omd.Code.t) =
       let c = {c with content = String.uppercase_ascii c.content} in
-      Omd.default_printer.code p b c
+      Omd.default_printer.code p add c
     in
-    let tag (p: Omd.printer) b (t: 'inline Omd.Tag.t) =
+    let tag (p: Omd.printer) add (t: 'inline Omd.Tag.t) =
       match t.tag with
       | "capitalize" ->
-        p.inline {p with text; code} b t.content
-      | _ -> Omd.default_printer.tag p b t
+        p.inline {p with text; code} add t.content
+      | _ -> Omd.default_printer.tag p add t
     in
-    let tag_block (p: Omd.printer) b t =
+    let tag_block (p: Omd.printer) add t =
       match t.Omd.Tag_block.tag with
       | "capitalize" ->
         let f i block =
-          p.block {p with text; code} b block;
+          p.block {p with text; code} add block;
           if i < List.length t.content - 1 then
-            Buffer.add_char b '\n'
+            add "\n"
         in
         List.iteri f t.content
-      | _ -> Omd.default_printer.tag_block p b t
+      | _ -> Omd.default_printer.tag_block p add t
     in
     {Omd.default_printer with tag; tag_block}
   in


### PR DESCRIPTION
Hi,

I needed a Mapper on the markdown Ast.
After implementing this it was only little work to also do a generic iterator.
I could easily rewrite the Html.default_printer using this iterator, but since the iterator provides no "context" argument, I had to wrap the html printer into a ``to_string`` closure instead of explicitely passing a ``Buffer.t`` around.
A nice side-effect is that one can now easily print directly to a channel without first filling a buffer.
I'm not sure whether the html part is an improvement, but at least it was a test case for the iterator. That's why I split off the html part into a separate commit. I would love to see the first commit merged, but am unsure about the second.