### PR TITLE
Cleanup main type signature

### DIFF
--- a/src/block.mli
+++ b/src/block.mli
@@ -1,17 +1,10 @@
-open Ast
-
-val same_list_kind: Block_list.kind -> Block_list.kind -> bool
-
-type 'a t = 'a block
-
 module Pre : sig
-  type block
   type t
 
   val empty: t
   val process: t -> string -> t
-  val finish: t -> block list
+  val finish: t -> Ast.Raw.t list
 
-  val of_channel: in_channel -> block list
-  val of_string: string -> block list
-end with type block := string t
+  val of_channel: in_channel -> Ast.Raw.t list
+  val of_string: string -> Ast.Raw.t list
+end

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,5 @@
 (library
  (name omd)
  (public_name omd)
+ (flags :standard -w -30)
  (libraries bigarray uchar))

--- a/src/markdown.ml
+++ b/src/markdown.ml
@@ -85,7 +85,7 @@ let print_attributes b a =
       Printf.bprintf b "}"
 
 let rec inline b = function
-  | Concat l ->
+  | Inline.Concat l ->
       List.iter (inline b) l
   | Text t ->
       Printf.bprintf b "%s" (escape_markdown_characters t)

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -1,48 +1,50 @@
+module Pre = Block.Pre
+
 include Ast
 
 type printer = Html.printer =
   {
-    document: printer       -> Buffer.t -> inline block list         -> unit;
+    document: printer       -> Buffer.t -> Block.t list              -> unit;
     attributes: printer     -> Buffer.t -> Attributes.t              -> unit;
-    block: printer          -> Buffer.t -> inline block              -> unit;
-    paragraph: printer      -> Buffer.t -> inline                    -> unit;
-    blockquote: printer     -> Buffer.t -> inline block list         -> unit;
-    list: printer           -> Buffer.t -> inline block Block_list.t -> unit;
-    code_block: printer     -> Buffer.t -> Code_block.t              -> unit;
+    block: printer          -> Buffer.t -> Block.t                   -> unit;
+    paragraph: printer      -> Buffer.t -> Inline.t                  -> unit;
+    blockquote: printer     -> Buffer.t -> Block.t list              -> unit;
+    list: printer           -> Buffer.t -> Block.block_list          -> unit;
+    code_block: printer     -> Buffer.t -> Block.code_block          -> unit;
     thematic_break: printer -> Buffer.t                              -> unit;
     html_block: printer     -> Buffer.t -> string                    -> unit;
-    heading: printer        -> Buffer.t -> inline Heading.t          -> unit;
-    def_list: printer       -> Buffer.t -> inline Def_list.t         -> unit;
-    tag_block: printer      -> Buffer.t -> inline block Tag_block.t  -> unit;
-    inline: printer         -> Buffer.t -> inline                    -> unit;
-    concat: printer         -> Buffer.t -> inline list               -> unit;
+    heading: printer        -> Buffer.t -> Block.heading             -> unit;
+    def_list: printer       -> Buffer.t -> Block.def_list            -> unit;
+    tag_block: printer      -> Buffer.t -> Block.tag_block           -> unit;
+    inline: printer         -> Buffer.t -> Inline.t                  -> unit;
+    concat: printer         -> Buffer.t -> Inline.t list             -> unit;
     text: printer           -> Buffer.t -> string                    -> unit;
-    emph: printer           -> Buffer.t -> inline Emph.t             -> unit;
-    code: printer           -> Buffer.t -> Code.t                    -> unit;
+    emph: printer           -> Buffer.t -> Inline.emph               -> unit;
+    code: printer           -> Buffer.t -> Inline.code               -> unit;
     hard_break: printer     -> Buffer.t                              -> unit;
     soft_break: printer     -> Buffer.t                              -> unit;
     html: printer           -> Buffer.t -> string                    -> unit;
-    link: printer           -> Buffer.t -> inline Link.t             -> unit;
-    ref: printer            -> Buffer.t -> inline Ref.t              -> unit;
-    tag: printer            -> Buffer.t -> inline Tag.t              -> unit;
+    link: printer           -> Buffer.t -> Inline.link               -> unit;
+    ref: printer            -> Buffer.t -> Inline.ref                -> unit;
+    tag: printer            -> Buffer.t -> Inline.tag                -> unit;
   }
 
-type t = inline block list
+type t = Block.t list
 
-let parse_inlines md =
+let parse_inlines (md : Raw.t list) =
   let parse_inline defs s = Parser.inline defs (Parser.P.of_string s) in
-  let defs = Ast.defs md in
+  let defs = Raw.defs md in
   let defs =
-    List.map (fun (def: string Link_def.t) -> {def with label = Parser.normalize def.label}) defs
+    List.map (fun (def: string link_def) -> {def with label = Parser.normalize def.label}) defs
   in
-  List.map (Ast.map (parse_inline defs)) md
+  List.map (Mapper.map (parse_inline defs)) md
 
 let of_channel ic =
-  let md = Block.Pre.of_channel ic in
+  let md = Pre.of_channel ic in
   parse_inlines md
 
 let of_string s =
-  let md = Block.Pre.of_string s in
+  let md = Pre.of_string s in
   parse_inlines md
 
 let default_printer = Html.default_printer

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -1,72 +1,177 @@
 (** A markdown parser in OCaml. *)
 
-module Attributes = Ast.Attributes
+module Attributes : sig
+  type t =
+    {
+      id: string option;
+      classes: string list;
+      attributes: (string * string) list;
+    }
+end
 
-module Link_def = Ast.Link_def
-module Block_list = Ast.Block_list
-module Code_block = Ast.Code_block
-module Heading = Ast.Heading
-module Def_list = Ast.Def_list
-module Tag_block = Ast.Tag_block
+type 'a link_def =
+  {
+    label: 'a;
+    destination: string;
+    title: string option;
+    attributes: Attributes.t;
+  }
 
-type 'a block = 'a Ast.block =
-  | Paragraph of 'a
-  | List of 'a block Block_list.t
-  | Blockquote of 'a block list
-  | Thematic_break
-  | Heading of 'a Heading.t
-  | Code_block of Code_block.t
-  | Html_block of string
-  | Link_def of string Link_def.t
-  | Def_list of 'a Def_list.t
-  | Tag_block of 'a block Tag_block.t
+type link_kind =
+  | Img
+  | Url
 
-module Emph = Ast.Emph
-module Code = Ast.Code
-module Link = Ast.Link
-module Ref = Ast.Ref
-module Tag = Ast.Tag
+type emph_kind =
+  | Normal
+  | Strong
 
-type inline = Ast.inline =
-  | Concat of inline list
-  | Text of string
-  | Emph of inline Emph.t
-  | Code of Code.t
-  | Hard_break
-  | Soft_break
-  | Link of inline Link.t
-  | Ref of inline Ref.t
-  | Html of string
-  | Tag of inline Tag.t
+type emph_style =
+  | Star
+  | Underscore
 
-type t = inline block list
+module Inline : sig
+  type emph =
+    {
+      style: emph_style;
+      kind: emph_kind;
+      content: t;
+    }
+
+  and code =
+    {
+      level: int;
+      content: string;
+      attributes: Attributes.t;
+    }
+
+  and link =
+    {
+      kind: link_kind;
+      def: t link_def;
+    }
+
+  and ref =
+    {
+      kind: link_kind;
+      label: t;
+      def: string link_def;
+    }
+
+  and tag =
+    {
+      tag: string;
+      content: t;
+      attributes: Attributes.t
+    }
+
+  and t =
+    | Concat of t list
+    | Text of string
+    | Emph of emph
+    | Code of code
+    | Hard_break
+    | Soft_break
+    | Link of link
+    | Ref of ref
+    | Html of string
+    | Tag of tag
+end
+
+type block_list_kind =
+  | Ordered of int * char
+  | Unordered of char
+
+type block_list_style =
+  | Loose
+  | Tight
+
+type code_block_kind =
+  | Tilde
+  | Backtick
+
+module Block : sig
+  type block_list =
+    {
+      kind: block_list_kind;
+      style: block_list_style;
+      blocks: t list list;
+    }
+
+  and code_block =
+    {
+      kind: code_block_kind option;
+      label: string option;
+      other: string option;
+      code: string option;
+      attributes: Attributes.t;
+    }
+
+  and heading =
+    {
+      level: int;
+      text: Inline.t;
+      attributes: Attributes.t;
+    }
+
+  and def_elt =
+    {
+      term: Inline.t;
+      defs: Inline.t list;
+    }
+
+  and def_list =
+    {
+      content: def_elt list
+    }
+
+  and tag_block =
+    {
+      tag: string;
+      content: t list;
+      attributes: Attributes.t
+    }
+
+  and t =
+    | Paragraph of Inline.t
+    | List of block_list
+    | Blockquote of t list
+    | Thematic_break
+    | Heading of heading
+    | Code_block of code_block
+    | Html_block of string
+    | Link_def of string link_def
+    | Def_list of def_list
+    | Tag_block of tag_block
+end
+
+type t = Block.t list
 (** A markdown document *)
 
-type printer = Html.printer =
+type printer =
   {
-    document: printer       -> Buffer.t -> inline block list         -> unit;
+    document: printer       -> Buffer.t -> Block.t list              -> unit;
     attributes: printer     -> Buffer.t -> Attributes.t              -> unit;
-    block: printer          -> Buffer.t -> inline block              -> unit;
-    paragraph: printer      -> Buffer.t -> inline                    -> unit;
-    blockquote: printer     -> Buffer.t -> inline block list         -> unit;
-    list: printer           -> Buffer.t -> inline block Block_list.t -> unit;
-    code_block: printer     -> Buffer.t -> Code_block.t              -> unit;
+    block: printer          -> Buffer.t -> Block.t                   -> unit;
+    paragraph: printer      -> Buffer.t -> Inline.t                  -> unit;
+    blockquote: printer     -> Buffer.t -> Block.t list              -> unit;
+    list: printer           -> Buffer.t -> Block.block_list          -> unit;
+    code_block: printer     -> Buffer.t -> Block.code_block          -> unit;
     thematic_break: printer -> Buffer.t                              -> unit;
     html_block: printer     -> Buffer.t -> string                    -> unit;
-    heading: printer        -> Buffer.t -> inline Heading.t          -> unit;
-    def_list: printer       -> Buffer.t -> inline Def_list.t         -> unit;
-    tag_block: printer      -> Buffer.t -> inline block Tag_block.t  -> unit;
-    inline: printer         -> Buffer.t -> inline                    -> unit;
-    concat: printer         -> Buffer.t -> inline list               -> unit;
+    heading: printer        -> Buffer.t -> Block.heading             -> unit;
+    def_list: printer       -> Buffer.t -> Block.def_list            -> unit;
+    tag_block: printer      -> Buffer.t -> Block.tag_block           -> unit;
+    inline: printer         -> Buffer.t -> Inline.t                  -> unit;
+    concat: printer         -> Buffer.t -> Inline.t list             -> unit;
     text: printer           -> Buffer.t -> string                    -> unit;
-    emph: printer           -> Buffer.t -> inline Emph.t             -> unit;
-    code: printer           -> Buffer.t -> Code.t                    -> unit;
+    emph: printer           -> Buffer.t -> Inline.emph               -> unit;
+    code: printer           -> Buffer.t -> Inline.code               -> unit;
     hard_break: printer     -> Buffer.t                              -> unit;
     soft_break: printer     -> Buffer.t                              -> unit;
     html: printer           -> Buffer.t -> string                    -> unit;
-    link: printer           -> Buffer.t -> inline Link.t             -> unit;
-    ref: printer            -> Buffer.t -> inline Ref.t              -> unit;
-    tag: printer            -> Buffer.t -> inline Tag.t              -> unit;
+    link: printer           -> Buffer.t -> Inline.link               -> unit;
+    ref: printer            -> Buffer.t -> Inline.ref                -> unit;
+    tag: printer            -> Buffer.t -> Inline.tag                -> unit;
   }
 
 val of_channel: in_channel -> t

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -6,13 +6,13 @@ type t =
 
 let atom s = Atom s
 
-let rec link_def : 'a. ('a -> t) -> 'a Link_def.t -> t =
+let rec link_def : 'a. ('a -> t) -> 'a link_def -> t =
   fun f {label; destination; title; _} ->
     let title = match title with Some title -> [Atom title] | None -> [] in
     List (Atom "link-def" :: f label :: Atom destination :: title)
 
 and inline = function
-  | Concat xs ->
+  | Inline.Concat xs ->
       List (Atom "concat" :: List.map inline xs)
   | Text s ->
       Atom s
@@ -38,7 +38,7 @@ and inline = function
       List [Atom "tag"; Atom tag; inline content]
 
 let rec block = function
-  | Paragraph x ->
+  | Block.Paragraph x ->
       List [Atom "paragraph"; inline x]
   | List l ->
       List (Atom "list" :: List.map (fun xs -> List (Atom "list-item" :: List.map block xs)) l.blocks)
@@ -61,7 +61,9 @@ let rec block = function
   | Link_def {label; destination; _} ->
       List [Atom "link-def"; Atom label; Atom destination]
   | Def_list {content} ->
-      List [Atom "def-list"; List (List.map (fun elt -> List [inline elt.Def_list.term; List (List.map inline elt.defs)]) content)]
+      List [Atom "def-list";
+            List (List.map (fun elt -> List [inline elt.Block.term;
+                                             List (List.map inline elt.defs)]) content)]
   | Tag_block {tag; content; _} ->
       List [Atom "tag"; Atom tag; List (List.map block content)]
 

--- a/src/text.ml
+++ b/src/text.ml
@@ -1,7 +1,7 @@
 open Ast
 
 let rec inline b = function
-  | Concat l ->
+  | Inline.Concat l ->
       List.iter (inline b) l
   | Text t ->
       Buffer.add_string b t
@@ -22,7 +22,7 @@ let rec inline b = function
       inline b t.content
 
 let block f b = function
-  | Paragraph x ->
+  | Block.Paragraph x ->
       f b x
   | _ ->
       assert false

--- a/tests/tag/uppercase.ml
+++ b/tests/tag/uppercase.ml
@@ -37,18 +37,18 @@ let main () =
       let t = String.uppercase_ascii t in
       Omd.default_printer.text p b t
     in
-    let code p b (c: Omd.Code.t) =
+    let code p b (c: Omd.Inline.code) =
       let c = {c with content = String.uppercase_ascii c.content} in
       Omd.default_printer.code p b c
     in
-    let tag (p: Omd.printer) b (t: 'inline Omd.Tag.t) =
+    let tag (p: Omd.printer) b (t: Omd.Inline.tag) =
       match t.tag with
       | "capitalize" ->
         p.inline {p with text; code} b t.content
       | _ -> Omd.default_printer.tag p b t
     in
     let tag_block (p: Omd.printer) b t =
-      match t.Omd.Tag_block.tag with
+      match t.Omd.Block.tag with
       | "capitalize" ->
         let f i block =
           p.block {p with text; code} b block;


### PR DESCRIPTION
See #198 

- Do not leak type variable in main types
- Flatten type hierarchy
- Cleanup public API (`omd.mli`)