### PR TITLE
Lighter representation for attributes

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -1,25 +1,12 @@
-module Attributes = struct
-  type t =
-    {
-      id: string option;
-      classes: string list;
-      attributes: (string * string) list;
-    }
-
-  let empty =
-    {
-      id = None;
-      classes = [];
-      attributes = [];
-    }
-end
+type attribute =
+  string * string
 
 type 'a link_def =
   {
     label: 'a;
     destination: string;
     title: string option;
-    attributes: Attributes.t;
+    attributes: attribute list;
   }
 
 type block_list_kind =
@@ -58,14 +45,14 @@ module MakeBlock (Inline : T) = struct
       label: string option;
       other: string option;
       code: string option;
-      attributes: Attributes.t;
+      attributes: attribute list;
     }
 
   and heading =
     {
       level: int;
       text: Inline.t;
-      attributes: Attributes.t;
+      attributes: attribute list;
     }
 
   and def_elt =
@@ -83,7 +70,7 @@ module MakeBlock (Inline : T) = struct
     {
       tag: string;
       content: t list;
-      attributes: Attributes.t
+      attributes: attribute list;
     }
 
   and t =
@@ -133,7 +120,7 @@ module Inline = struct
     {
       level: int;
       content: string;
-      attributes: Attributes.t;
+      attributes: attribute list;
     }
 
   and link =
@@ -153,7 +140,7 @@ module Inline = struct
     {
       tag: string;
       content: t;
-      attributes: Attributes.t
+      attributes: attribute list;
     }
 
   and t =

--- a/src/block.ml
+++ b/src/block.ml
@@ -7,11 +7,11 @@ module Pre = struct
     | Rblockquote of t
     | Rlist of block_list_kind * block_list_style * bool * int * Raw.t list list * t
     | Rparagraph of string list
-    | Rfenced_code of int * int * code_block_kind * (string * string) * string list * Attributes.t
+    | Rfenced_code of int * int * code_block_kind * (string * string) * string list * attribute list
     | Rindented_code of string list
     | Rhtml of Parser.html_kind * string list
     | Rdef_list of string * string list
-    | Rtag of int * int * string * t * Attributes.t
+    | Rtag of int * int * string * t * attribute list
     | Rempty
 
   and t =
@@ -64,7 +64,7 @@ module Pre = struct
         Tag_block {tag; content = close state; attributes} :: blocks
     | Rindented_code l -> (* TODO: trim from the right *)
         let rec loop = function "" :: l -> loop l | _ as l -> l in
-        Code_block {kind = None; label = None; other = None; code = Some (concat (loop l)); attributes = Attributes.empty} :: blocks
+        Code_block {kind = None; label = None; other = None; code = Some (concat (loop l)); attributes = []} :: blocks
     | Rhtml (_, l) ->
         Html_block (concat l) :: blocks
     | Rempty ->
@@ -113,7 +113,7 @@ module Pre = struct
                     | Latx_heading _ | Lfenced_code _ | Lhtml (true, _)) ->
         process {blocks = close {blocks; next}; next = Rempty} s
     | Rparagraph (_ :: _ as lines), Lsetext_heading (level, _) ->
-        {blocks = Heading {level; text= String.trim (String.concat "\n" (List.rev lines)); attributes = Attributes.empty}:: blocks; next = Rempty}
+        {blocks = Heading {level; text= String.trim (String.concat "\n" (List.rev lines)); attributes = []}:: blocks; next = Rempty}
     | Rparagraph lines, _ ->
         {blocks; next = Rparagraph (Sub.to_string s :: lines)}
     | Rfenced_code (_, num, q, _, _, _), Lfenced_code (_, num', q1, ("", _), _) when num' >= num && q = q1 ->

--- a/src/html.ml
+++ b/src/html.ml
@@ -1,8 +1,5 @@
 open Ast
 
-type attribute =
-  string * string
-
 type element_type =
   | Inline
   | Block
@@ -101,17 +98,6 @@ let to_plain_text t =
   go t;
   Buffer.contents buf
 
-let attr {Attributes.id; classes; attributes} =
-  let a =
-    if classes <> [] then
-      ("class", String.concat " " classes) :: attributes
-    else
-      attributes
-  in
-  match id with
-  | None -> a
-  | Some s -> ("id", s) :: a
-
 let nl = Raw "\n"
 
 let rec url label destination title attrs =
@@ -148,7 +134,7 @@ and inline = function
       in
       elt Inline name [] (Some (inline content))
   | Code {level = _; attributes; content} ->
-      elt Inline "code" (attr attributes) (Some (text content))
+      elt Inline "code" attributes (Some (text content))
   | Hard_break ->
       concat (elt Inline "br" [] None) nl
   | Soft_break ->
@@ -156,13 +142,13 @@ and inline = function
   | Html body ->
       raw body
   | Link {kind = Url; def = {label; destination; title; attributes}; _} ->
-      url label destination title (attr attributes)
+      url label destination title attributes
   | Link {kind = Img; def = {label; destination; title; attributes}; _} ->
-      img label destination title (attr attributes)
+      img label destination title attributes
   | Ref {kind = Url; label; def = {destination; title; attributes; _}; _} ->
-      url label destination title (attr attributes)
+      url label destination title attributes
   | Ref {kind = Img; label; def = {destination; title; attributes; _}; _} ->
-      img label destination title (attr attributes)
+      img label destination title attributes
   | Tag {tag = _; attributes = _; content} ->
       inline content
 
@@ -209,7 +195,7 @@ let rec block = function
         | Some c ->
             text c
       in
-      elt Block "pre" (attr attributes)
+      elt Block "pre" attributes
         (Some (elt Inline "code" attrs (Some c)))
   | Thematic_break ->
       elt Block "hr" [] None
@@ -226,7 +212,7 @@ let rec block = function
         | 6 -> "h6"
         | _ -> "p"
       in
-      elt Block name (attr attributes)
+      elt Block name attributes
         (Some (inline text))
   | Def_list {content} ->
       let f {Block.term; defs} =

--- a/src/html.mli
+++ b/src/html.mli
@@ -1,5 +1,4 @@
-type attribute =
-  string * string
+open Ast
 
 type element_type =
   | Inline
@@ -12,7 +11,7 @@ type t =
   | Null
   | Concat of t * t
 
-val of_doc : Ast.Block.t list -> t
+val of_doc : Block.t list -> t
 
 val to_string : t -> string
 

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -1,20 +1,14 @@
 (** A markdown parser in OCaml. *)
 
-module Attributes : sig
-  type t =
-    {
-      id: string option;
-      classes: string list;
-      attributes: (string * string) list;
-    }
-end
+type attribute =
+  string * string
 
 type 'a link_def =
   {
     label: 'a;
     destination: string;
     title: string option;
-    attributes: Attributes.t;
+    attributes: attribute list;
   }
 
 type link_kind =
@@ -41,7 +35,7 @@ module Inline : sig
     {
       level: int;
       content: string;
-      attributes: Attributes.t;
+      attributes: attribute list;
     }
 
   and link =
@@ -61,7 +55,7 @@ module Inline : sig
     {
       tag: string;
       content: t;
-      attributes: Attributes.t
+      attributes: attribute list;
     }
 
   and t =
@@ -103,14 +97,14 @@ module Block : sig
       label: string option;
       other: string option;
       code: string option;
-      attributes: Attributes.t;
+      attributes: attribute list;
     }
 
   and heading =
     {
       level: int;
       text: Inline.t;
-      attributes: Attributes.t;
+      attributes: attribute list;
     }
 
   and def_elt =
@@ -128,7 +122,7 @@ module Block : sig
     {
       tag: string;
       content: t list;
-      attributes: Attributes.t
+      attributes: attribute list;
     }
 
   and t =


### PR DESCRIPTION
Simplify the representation for attributes, share the type with the HTML backend.