### PR TITLE
Simplify ast

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -33,11 +33,6 @@ module MakeBlock (I : T) = struct
       defs: I.t list;
     }
 
-  and def_list =
-    {
-      content: def_elt list
-    }
-
   and block =
     {
       bl_desc: block_desc;
@@ -53,7 +48,7 @@ module MakeBlock (I : T) = struct
     | Code_block of string * string
     | Html_block of string
     | Link_def of string link_def
-    | Def_list of def_list
+    | Definition_list of def_elt list
 
   let defs ast =
     let rec loop acc {bl_desc; bl_attributes} =
@@ -61,7 +56,7 @@ module MakeBlock (I : T) = struct
       | List (_, _, bls) -> List.fold_left (List.fold_left loop) acc bls
       | Blockquote l -> List.fold_left loop acc l
       | Paragraph _ | Thematic_break | Heading _
-      | Def_list _ | Code_block _ | Html_block _ -> acc
+      | Definition_list _ | Code_block _ | Html_block _ -> acc
       | Link_def def -> (def, bl_attributes) :: acc
     in
     List.rev (List.fold_left loop [] ast)
@@ -108,9 +103,9 @@ module MakeMapper (Src : T) (Dst : T) = struct
           Thematic_break
       | Heading (level, text) ->
           Heading (level, f text)
-      | Def_list {content} ->
+      | Definition_list l ->
           let f {SrcBlock.term; defs} = {DstBlock.term = f term; defs = List.map f defs} in
-          Def_list {content = List.map f content}
+          Definition_list (List.map f l)
       | Code_block (label, code) ->
           Code_block (label, code)
       | Html_block x ->

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -37,8 +37,8 @@ module MakeBlock (Inline : T) = struct
 
   and code_block =
     {
-      label: string option;
-      code: string option;
+      label: string;
+      code: string;
       attributes: attribute list;
     }
 

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -95,7 +95,6 @@ type link_kind =
 module Inline = struct
   type code =
     {
-      level: int;
       content: string;
       attributes: attribute list;
     }

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -34,12 +34,6 @@ module MakeBlock (Inline : T) = struct
       blocks: t list list;
     }
 
-  and heading =
-    {
-      level: int;
-      text: Inline.t;
-    }
-
   and def_elt =
     {
       term: Inline.t;
@@ -62,7 +56,7 @@ module MakeBlock (Inline : T) = struct
     | List of block_list
     | Blockquote of t list
     | Thematic_break
-    | Heading of heading
+    | Heading of int * Inline.t
     | Code_block of string * string
     | Html_block of string
     | Link_def of string link_def
@@ -124,8 +118,8 @@ module MakeMapper (Src : T) (Dst : T) = struct
           Blockquote (List.map (map f) xs)
       | Thematic_break ->
           Thematic_break
-      | Heading {level; text} ->
-          Heading {level; text = f text}
+      | Heading (level, text) ->
+          Heading (level, f text)
       | Def_list {content} ->
           let f {SrcBlock.term; defs} = {DstBlock.term = f term; defs = List.map f defs} in
           Def_list {content = List.map f content}

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -105,13 +105,6 @@ module Inline = struct
       def: t link_def;
     }
 
-  and ref =
-    {
-      kind: link_kind;
-      label: t;
-      def: string link_def;
-    }
-
   and t =
     | Concat of t list
     | Text of string
@@ -121,7 +114,6 @@ module Inline = struct
     | Hard_break
     | Soft_break
     | Link of link
-    | Ref of ref
     | Html of string
 end
 

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -92,18 +92,8 @@ type link_kind =
   | Img
   | Url
 
-type emph_kind =
-  | Normal
-  | Strong
-
 module Inline = struct
-  type emph =
-    {
-      kind: emph_kind;
-      content: t;
-    }
-
-  and code =
+  type code =
     {
       level: int;
       content: string;
@@ -126,7 +116,8 @@ module Inline = struct
   and t =
     | Concat of t list
     | Text of string
-    | Emph of emph
+    | Emph of t
+    | Strong of t
     | Code of code
     | Hard_break
     | Soft_break

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -68,12 +68,7 @@ module MakeBlock (Inline : T) = struct
 end
 
 module Inline = struct
-  type code =
-    {
-      content: string;
-    }
-
-  and t =
+  type t =
     {
       il_desc: t_desc;
       il_attributes: attributes;
@@ -84,7 +79,7 @@ module Inline = struct
     | Text of string
     | Emph of t
     | Strong of t
-    | Code of code
+    | Code of string
     | Hard_break
     | Soft_break
     | Link of t link_def

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -96,14 +96,9 @@ type emph_kind =
   | Normal
   | Strong
 
-type emph_style =
-  | Star
-  | Underscore
-
 module Inline = struct
   type emph =
     {
-      style: emph_style;
       kind: emph_kind;
       content: t;
     }

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -23,10 +23,6 @@ type block_list_style =
   | Loose
   | Tight
 
-type code_block_kind =
-  | Tilde
-  | Backtick
-
 module type T = sig
   type t
 end
@@ -41,9 +37,7 @@ module MakeBlock (Inline : T) = struct
 
   and code_block =
     {
-      kind: code_block_kind option;
       label: string option;
-      other: string option;
       code: string option;
       attributes: attribute list;
     }
@@ -129,8 +123,8 @@ module MakeMapper (Src : T) (Dst : T) = struct
     | Def_list {content} ->
         let f {SrcBlock.term; defs} = {DstBlock.term = f term; defs = List.map f defs} in
         Def_list {content = List.map f content}
-    | Code_block {kind; label; other; code; attributes} ->
-        Code_block {kind; label; other; code; attributes}
+    | Code_block {label; code; attributes} ->
+        Code_block {label; code; attributes}
     | Html_block x ->
         Html_block x
     | Link_def x ->

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -34,12 +34,6 @@ module MakeBlock (Inline : T) = struct
       blocks: t list list;
     }
 
-  and code_block =
-    {
-      label: string;
-      code: string;
-    }
-
   and heading =
     {
       level: int;
@@ -69,7 +63,7 @@ module MakeBlock (Inline : T) = struct
     | Blockquote of t list
     | Thematic_break
     | Heading of heading
-    | Code_block of code_block
+    | Code_block of string * string
     | Html_block of string
     | Link_def of string link_def
     | Def_list of def_list
@@ -135,8 +129,8 @@ module MakeMapper (Src : T) (Dst : T) = struct
       | Def_list {content} ->
           let f {SrcBlock.term; defs} = {DstBlock.term = f term; defs = List.map f defs} in
           Def_list {content = List.map f content}
-      | Code_block {label; code} ->
-          Code_block {label; code}
+      | Code_block (label, code) ->
+          Code_block (label, code)
       | Html_block x ->
           Html_block x
       | Link_def x ->

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -88,21 +88,11 @@ module MakeBlock (Inline : T) = struct
     List.rev (List.fold_left loop [] ast)
 end
 
-type link_kind =
-  | Img
-  | Url
-
 module Inline = struct
   type code =
     {
       content: string;
       attributes: attribute list;
-    }
-
-  and link =
-    {
-      kind: link_kind;
-      def: t link_def;
     }
 
   and t =
@@ -113,7 +103,8 @@ module Inline = struct
     | Code of code
     | Hard_break
     | Soft_break
-    | Link of link
+    | Link of t link_def
+    | Image of t link_def
     | Html of string
 end
 

--- a/src/block.ml
+++ b/src/block.ml
@@ -49,9 +49,9 @@ module Pre = struct
         let blocks = List.fold_right (fun def blocks -> Raw.Link_def def :: blocks) defs blocks in
         if s = "" then blocks else Paragraph s :: blocks
     | Rfenced_code (_, _, _kind, (label, _other), [], a) ->
-        Code_block {label = Some label; code = None; attributes = a} :: blocks
+        Code_block {label; code = ""; attributes = a} :: blocks
     | Rfenced_code (_, _, _kind, (label, _other), l, a) ->
-        Code_block {label = Some label; code = Some (concat l); attributes = a} :: blocks
+        Code_block {label; code = concat l; attributes = a} :: blocks
     | Rdef_list (term, defs) ->
         let l, blocks =
           match blocks with
@@ -61,7 +61,7 @@ module Pre = struct
         Def_list {content = l @ [{ Raw.term; defs = List.rev defs}]} :: blocks
     | Rindented_code l -> (* TODO: trim from the right *)
         let rec loop = function "" :: l -> loop l | _ as l -> l in
-        Code_block {label = None; code = Some (concat (loop l)); attributes = []} :: blocks
+        Code_block {label = ""; code = concat (loop l); attributes = []} :: blocks
     | Rhtml (_, l) ->
         Html_block (concat l) :: blocks
     | Rempty ->

--- a/src/block.ml
+++ b/src/block.ml
@@ -7,7 +7,7 @@ module Pre = struct
     | Rblockquote of t
     | Rlist of block_list_kind * block_list_style * bool * int * Raw.t list list * t
     | Rparagraph of string list
-    | Rfenced_code of int * int * code_block_kind * (string * string) * string list * attribute list
+    | Rfenced_code of int * int * Parser.code_block_kind * (string * string) * string list * attribute list
     | Rindented_code of string list
     | Rhtml of Parser.html_kind * string list
     | Rdef_list of string * string list
@@ -48,10 +48,10 @@ module Pre = struct
         let s = String.sub s off (String.length s - off) |> String.trim in
         let blocks = List.fold_right (fun def blocks -> Raw.Link_def def :: blocks) defs blocks in
         if s = "" then blocks else Paragraph s :: blocks
-    | Rfenced_code (_, _, kind, (label, other), [], a) ->
-        Code_block {kind = Some kind; label = Some label; other = Some other; code = None; attributes = a} :: blocks
-    | Rfenced_code (_, _, kind, (label, other), l, a) ->
-        Code_block {kind = Some kind; label = Some label; other = Some other; code = Some (concat l); attributes = a} :: blocks
+    | Rfenced_code (_, _, _kind, (label, _other), [], a) ->
+        Code_block {label = Some label; code = None; attributes = a} :: blocks
+    | Rfenced_code (_, _, _kind, (label, _other), l, a) ->
+        Code_block {label = Some label; code = Some (concat l); attributes = a} :: blocks
     | Rdef_list (term, defs) ->
         let l, blocks =
           match blocks with
@@ -61,7 +61,7 @@ module Pre = struct
         Def_list {content = l @ [{ Raw.term; defs = List.rev defs}]} :: blocks
     | Rindented_code l -> (* TODO: trim from the right *)
         let rec loop = function "" :: l -> loop l | _ as l -> l in
-        Code_block {kind = None; label = None; other = None; code = Some (concat (loop l)); attributes = []} :: blocks
+        Code_block {label = None; code = Some (concat (loop l)); attributes = []} :: blocks
     | Rhtml (_, l) ->
         Html_block (concat l) :: blocks
     | Rempty ->

--- a/src/block.ml
+++ b/src/block.ml
@@ -8,7 +8,7 @@ let mk ?(attr = []) desc =
 module Pre = struct
   type container =
     | Rblockquote of t
-    | Rlist of list_type * list_spacing * bool * int * Raw.t list list * t
+    | Rlist of list_type * list_spacing * bool * int * Raw.block list list * t
     | Rparagraph of string list
     | Rfenced_code of int * int * Parser.code_block_kind * (string * string) * string list * attributes
     | Rindented_code of string list
@@ -18,7 +18,7 @@ module Pre = struct
 
   and t =
     {
-      blocks: Raw.t list;
+      blocks: Raw.block list;
       next: container;
     }
 

--- a/src/block.ml
+++ b/src/block.ml
@@ -2,12 +2,15 @@ open Ast
 
 module Sub = Parser.Sub
 
+let mk ?(attr = []) desc =
+  {Ast.Raw.bl_desc = desc; bl_attributes = attr}
+
 module Pre = struct
   type container =
     | Rblockquote of t
     | Rlist of block_list_kind * block_list_style * bool * int * Raw.t list list * t
     | Rparagraph of string list
-    | Rfenced_code of int * int * Parser.code_block_kind * (string * string) * string list * attribute list
+    | Rfenced_code of int * int * Parser.code_block_kind * (string * string) * string list * attributes
     | Rindented_code of string list
     | Rhtml of Parser.html_kind * string list
     | Rdef_list of string * string list
@@ -39,31 +42,34 @@ module Pre = struct
   let rec close {blocks; next} =
     match next with
     | Rblockquote state ->
-        Raw.Blockquote (finish state) :: blocks
+        mk (Raw.Blockquote (finish state)) :: blocks
     | Rlist (kind, style, _, _, closed_items, state) ->
-        List {kind; style; blocks = List.rev (finish state :: closed_items)} :: blocks
+        mk (List {kind; style; blocks = List.rev (finish state :: closed_items)}) :: blocks
     | Rparagraph l ->
         let s = concat (List.map trim_left l) in
         let defs, off = Parser.link_reference_definitions (Parser.P.of_string s) in
         let s = String.sub s off (String.length s - off) |> String.trim in
-        let blocks = List.fold_right (fun def blocks -> Raw.Link_def def :: blocks) defs blocks in
-        if s = "" then blocks else Paragraph s :: blocks
-    | Rfenced_code (_, _, _kind, (label, _other), [], a) ->
-        Code_block {label; code = ""; attributes = a} :: blocks
-    | Rfenced_code (_, _, _kind, (label, _other), l, a) ->
-        Code_block {label; code = concat l; attributes = a} :: blocks
+        let blocks =
+          let f (def, attr) blocks = mk ~attr (Raw.Link_def def) :: blocks in
+          List.fold_right f defs blocks
+        in
+        if s = "" then blocks else mk (Paragraph s) :: blocks
+    | Rfenced_code (_, _, _kind, (label, _other), [], attr) ->
+        mk ~attr (Code_block {label; code = ""}) :: blocks
+    | Rfenced_code (_, _, _kind, (label, _other), l, attr) ->
+        mk ~attr (Code_block {label; code = concat l}) :: blocks
     | Rdef_list (term, defs) ->
         let l, blocks =
           match blocks with
-          | Def_list l :: b -> l.content, b
+          | {Raw.bl_desc = Def_list {content}; _} :: b -> content, b
           | b -> [], b
         in
-        Def_list {content = l @ [{ Raw.term; defs = List.rev defs}]} :: blocks
+        mk (Raw.Def_list {content = l @ [{ Raw.term; defs = List.rev defs}]}) :: blocks
     | Rindented_code l -> (* TODO: trim from the right *)
         let rec loop = function "" :: l -> loop l | _ as l -> l in
-        Code_block {label = ""; code = concat (loop l); attributes = []} :: blocks
+        mk (Code_block {label = ""; code = concat (loop l)}) :: blocks
     | Rhtml (_, l) ->
-        Html_block (concat l) :: blocks
+        mk (Html_block (concat l)) :: blocks
     | Rempty ->
         blocks
 
@@ -83,11 +89,11 @@ module Pre = struct
     | Rempty, Lblockquote s ->
         {blocks; next = Rblockquote (process empty s)}
     | Rempty, Lthematic_break ->
-        {blocks = Thematic_break :: blocks; next = Rempty}
+        {blocks = mk Thematic_break :: blocks; next = Rempty}
     | Rempty, Lsetext_heading (2, n) when n >= 3 ->
-        {blocks = Thematic_break :: blocks; next = Rempty}
-    | Rempty, Latx_heading (level, text, attributes) ->
-        {blocks = Heading {level; text; attributes} :: blocks; next = Rempty}
+        {blocks = mk Thematic_break :: blocks; next = Rempty}
+    | Rempty, Latx_heading (level, text, attr) ->
+        {blocks = mk ~attr (Heading {level; text}) :: blocks; next = Rempty}
     | Rempty, Lfenced_code (ind, num, q, info, a) ->
         {blocks; next = Rfenced_code (ind, num, q, info, [], a)}
     | Rempty, Lhtml (_, kind) ->
@@ -108,7 +114,8 @@ module Pre = struct
                     | Latx_heading _ | Lfenced_code _ | Lhtml (true, _)) ->
         process {blocks = close {blocks; next}; next = Rempty} s
     | Rparagraph (_ :: _ as lines), Lsetext_heading (level, _) ->
-        {blocks = Heading {level; text= String.trim (String.concat "\n" (List.rev lines)); attributes = []}:: blocks; next = Rempty}
+        let text = String.trim (String.concat "\n" (List.rev lines)) in
+        {blocks = mk (Heading {level; text}) :: blocks; next = Rempty}
     | Rparagraph lines, _ ->
         {blocks; next = Rparagraph (Sub.to_string s :: lines)}
     | Rfenced_code (_, num, q, _, _, _), Lfenced_code (_, num', q1, ("", _), _) when num' >= num && q = q1 ->

--- a/src/block.ml
+++ b/src/block.ml
@@ -61,10 +61,10 @@ module Pre = struct
     | Rdef_list (term, defs) ->
         let l, blocks =
           match blocks with
-          | {Raw.bl_desc = Def_list {content}; _} :: b -> content, b
+          | {Raw.bl_desc = Definition_list l; _} :: b -> l, b
           | b -> [], b
         in
-        mk (Raw.Def_list {content = l @ [{ Raw.term; defs = List.rev defs}]}) :: blocks
+        mk (Raw.Definition_list (l @ [{ Raw.term; defs = List.rev defs}])) :: blocks
     | Rindented_code l -> (* TODO: trim from the right *)
         let rec loop = function "" :: l -> loop l | _ as l -> l in
         mk (Code_block ("", concat (loop l))) :: blocks

--- a/src/block.ml
+++ b/src/block.ml
@@ -55,9 +55,9 @@ module Pre = struct
         in
         if s = "" then blocks else mk (Paragraph s) :: blocks
     | Rfenced_code (_, _, _kind, (label, _other), [], attr) ->
-        mk ~attr (Code_block {label; code = ""}) :: blocks
+        mk ~attr (Code_block (label, "")) :: blocks
     | Rfenced_code (_, _, _kind, (label, _other), l, attr) ->
-        mk ~attr (Code_block {label; code = concat l}) :: blocks
+        mk ~attr (Code_block (label, concat l)) :: blocks
     | Rdef_list (term, defs) ->
         let l, blocks =
           match blocks with
@@ -67,7 +67,7 @@ module Pre = struct
         mk (Raw.Def_list {content = l @ [{ Raw.term; defs = List.rev defs}]}) :: blocks
     | Rindented_code l -> (* TODO: trim from the right *)
         let rec loop = function "" :: l -> loop l | _ as l -> l in
-        mk (Code_block {label = ""; code = concat (loop l)}) :: blocks
+        mk (Code_block ("", concat (loop l))) :: blocks
     | Rhtml (_, l) ->
         mk (Html_block (concat l)) :: blocks
     | Rempty ->

--- a/src/block.ml
+++ b/src/block.ml
@@ -93,7 +93,7 @@ module Pre = struct
     | Rempty, Lsetext_heading (2, n) when n >= 3 ->
         {blocks = mk Thematic_break :: blocks; next = Rempty}
     | Rempty, Latx_heading (level, text, attr) ->
-        {blocks = mk ~attr (Heading {level; text}) :: blocks; next = Rempty}
+        {blocks = mk ~attr (Heading (level, text)) :: blocks; next = Rempty}
     | Rempty, Lfenced_code (ind, num, q, info, a) ->
         {blocks; next = Rfenced_code (ind, num, q, info, [], a)}
     | Rempty, Lhtml (_, kind) ->
@@ -115,7 +115,7 @@ module Pre = struct
         process {blocks = close {blocks; next}; next = Rempty} s
     | Rparagraph (_ :: _ as lines), Lsetext_heading (level, _) ->
         let text = String.trim (String.concat "\n" (List.rev lines)) in
-        {blocks = mk (Heading {level; text}) :: blocks; next = Rempty}
+        {blocks = mk (Heading (level, text)) :: blocks; next = Rempty}
     | Rparagraph lines, _ ->
         {blocks; next = Rparagraph (Sub.to_string s :: lines)}
     | Rfenced_code (_, num, q, _, _, _), Lfenced_code (_, num', q1, ("", _), _) when num' >= num && q = q1 ->

--- a/src/block.mli
+++ b/src/block.mli
@@ -3,8 +3,8 @@ module Pre : sig
 
   val empty: t
   val process: t -> string -> t
-  val finish: t -> Ast.Raw.t list
+  val finish: t -> Ast.Raw.block list
 
-  val of_channel: in_channel -> Ast.Raw.t list
-  val of_string: string -> Ast.Raw.t list
+  val of_channel: in_channel -> Ast.Raw.block list
+  val of_string: string -> Ast.Raw.block list
 end

--- a/src/html.ml
+++ b/src/html.ml
@@ -142,10 +142,6 @@ and inline = function
       url label destination title attributes
   | Link {kind = Img; def = {label; destination; title; attributes}; _} ->
       img label destination title attributes
-  | Ref {kind = Url; label; def = {destination; title; attributes; _}; _} ->
-      url label destination title attributes
-  | Ref {kind = Img; label; def = {destination; title; attributes; _}; _} ->
-      img label destination title attributes
 
 let rec block = function
   | Block.Blockquote q ->

--- a/src/html.ml
+++ b/src/html.ml
@@ -121,9 +121,9 @@ and img label destination title attrs =
   in
   elt Inline "img" attrs None
 
-and inline {Inline.il_desc; il_attributes = attr} =
+and inline {il_desc; il_attributes = attr} =
   match il_desc with
-  | Inline.Concat l ->
+  | Concat l ->
       concat_map inline l
   | Text t ->
       text t
@@ -144,9 +144,9 @@ and inline {Inline.il_desc; il_attributes = attr} =
   | Image {label; destination; title} ->
       img label destination title attr
 
-let rec block {Block.bl_desc; bl_attributes = attr} =
+let rec block {bl_desc; bl_attributes = attr} =
   match bl_desc with
-  | Block.Blockquote q ->
+  | Blockquote q ->
       elt Block "blockquote" attr
         (Some (concat nl (concat_map block q)))
   | Paragraph md ->
@@ -162,8 +162,8 @@ let rec block {Block.bl_desc; bl_attributes = attr} =
       in
       let li t =
         let block' t =
-          match t.Block.bl_desc, sp with
-          | Block.Paragraph t, Tight -> concat (inline t) nl
+          match t.bl_desc, sp with
+          | Paragraph t, Tight -> concat (inline t) nl
           | _ -> block t
         in
         let nl = if sp = Tight then Null else nl in
@@ -194,7 +194,7 @@ let rec block {Block.bl_desc; bl_attributes = attr} =
       in
       elt Block name attr (Some (inline text))
   | Def_list {content} ->
-      let f {Block.term; defs} =
+      let f {term; defs} =
         concat
           (elt Block "dt" [] (Some (inline term)))
           (concat_map (fun s -> elt Block "dd" [] (Some (inline s))) defs)

--- a/src/html.ml
+++ b/src/html.ml
@@ -130,7 +130,7 @@ and inline = function
       elt Inline "em" [] (Some (inline il))
   | Strong il ->
       elt Inline "strong" [] (Some (inline il))
-  | Code {level = _; attributes; content} ->
+  | Code {attributes; content} ->
       elt Inline "code" attributes (Some (text content))
   | Hard_break ->
       concat (elt Inline "br" [] None) nl

--- a/src/html.ml
+++ b/src/html.ml
@@ -185,7 +185,7 @@ let rec block {Block.bl_desc; bl_attributes = attr} =
       elt Block "hr" attr None
   | Html_block body ->
       raw body
-  | Heading {level; text} ->
+  | Heading (level, text) ->
       let name =
         match level with
         | 1 -> "h1"

--- a/src/html.ml
+++ b/src/html.ml
@@ -193,13 +193,13 @@ let rec block {bl_desc; bl_attributes = attr} =
         | _ -> "p"
       in
       elt Block name attr (Some (inline text))
-  | Def_list {content} ->
+  | Definition_list l ->
       let f {term; defs} =
         concat
           (elt Block "dt" [] (Some (inline term)))
           (concat_map (fun s -> elt Block "dd" [] (Some (inline s))) defs)
       in
-      elt Block "dl" attr (Some (concat_map f content))
+      elt Block "dl" attr (Some (concat_map f l))
   | Link_def _ ->
       Null
 

--- a/src/html.ml
+++ b/src/html.ml
@@ -138,9 +138,9 @@ and inline = function
       nl
   | Html body ->
       raw body
-  | Link {kind = Url; def = {label; destination; title; attributes}; _} ->
+  | Link {label; destination; title; attributes} ->
       url label destination title attributes
-  | Link {kind = Img; def = {label; destination; title; attributes}; _} ->
+  | Image {label; destination; title; attributes} ->
       img label destination title attributes
 
 let rec block = function

--- a/src/html.ml
+++ b/src/html.ml
@@ -131,8 +131,8 @@ and inline {Inline.il_desc; il_attributes = attr} =
       elt Inline "em" attr (Some (inline il))
   | Strong il ->
       elt Inline "strong" attr (Some (inline il))
-  | Code {content} ->
-      elt Inline "code" attr (Some (text content))
+  | Code s ->
+      elt Inline "code" attr (Some (text s))
   | Hard_break ->
       concat (elt Inline "br" attr None) nl
   | Soft_break ->

--- a/src/html.ml
+++ b/src/html.ml
@@ -173,7 +173,7 @@ let rec block {Block.bl_desc; bl_attributes = attr} =
         let nl = if style = Tight then Null else nl in
         elt Block "li" [] (Some (concat nl (concat_map block' t))) in
       elt Block name attr (Some (concat nl (concat_map li blocks)))
-  | Code_block {label; code} ->
+  | Code_block (label, code) ->
       let code_attr =
         if String.trim label = "" then []
         else ["class", "language-" ^ label]

--- a/src/html.ml
+++ b/src/html.ml
@@ -173,19 +173,10 @@ let rec block = function
       elt Block name attrs (Some (concat nl (concat_map li blocks)))
   | Code_block {label; attributes; code} ->
       let attrs =
-        match label with
-        | None -> []
-        | Some language ->
-            if String.trim language = "" then []
-            else ["class", "language-" ^ language]
+        if String.trim label = "" then []
+        else ["class", "language-" ^ label]
       in
-      let c =
-        match code with
-        | None ->
-            Null
-        | Some c ->
-            text c
-      in
+      let c = text code in
       elt Block "pre" attributes
         (Some (elt Inline "code" attrs (Some c)))
   | Thematic_break ->

--- a/src/html.ml
+++ b/src/html.ml
@@ -126,7 +126,7 @@ and inline = function
       concat_map inline l
   | Text t ->
       text t
-  | Emph {kind; style = _; content} ->
+  | Emph {kind; content} ->
       let name =
         match kind with
         | Normal -> "em"

--- a/src/html.ml
+++ b/src/html.ml
@@ -171,7 +171,7 @@ let rec block = function
         let nl = if style = Tight then Null else nl in
         elt Block "li" [] (Some (concat nl (concat_map block' t))) in
       elt Block name attrs (Some (concat nl (concat_map li blocks)))
-  | Code_block {kind = _; other = _; label; attributes; code} ->
+  | Code_block {label; attributes; code} ->
       let attrs =
         match label with
         | None -> []

--- a/src/html.ml
+++ b/src/html.ml
@@ -126,13 +126,10 @@ and inline = function
       concat_map inline l
   | Text t ->
       text t
-  | Emph {kind; content} ->
-      let name =
-        match kind with
-        | Normal -> "em"
-        | Strong -> "strong"
-      in
-      elt Inline name [] (Some (inline content))
+  | Emph il ->
+      elt Inline "em" [] (Some (inline il))
+  | Strong il ->
+      elt Inline "strong" [] (Some (inline il))
   | Code {level = _; attributes; content} ->
       elt Inline "code" attributes (Some (text content))
   | Hard_break ->

--- a/src/html.ml
+++ b/src/html.ml
@@ -151,14 +151,10 @@ let rec block {Block.bl_desc; bl_attributes = attr} =
         (Some (concat nl (concat_map block q)))
   | Paragraph md ->
       elt Block "p" attr (Some (inline md))
-  | List {kind; style; blocks} ->
-      let name =
-        match kind with
-        | Ordered _ -> "ol"
-        | Unordered _ -> "ul"
-      in
+  | List (ty, sp, bl) ->
+      let name = match ty with Ordered _ -> "ol" | Bullet _ -> "ul" in
       let attr =
-        match kind with
+        match ty with
         | Ordered (n, _) when n <> 1 ->
             ("start", string_of_int n) :: attr
         | _ ->
@@ -166,13 +162,13 @@ let rec block {Block.bl_desc; bl_attributes = attr} =
       in
       let li t =
         let block' t =
-          match t.Block.bl_desc, style with
+          match t.Block.bl_desc, sp with
           | Block.Paragraph t, Tight -> concat (inline t) nl
           | _ -> block t
         in
-        let nl = if style = Tight then Null else nl in
+        let nl = if sp = Tight then Null else nl in
         elt Block "li" [] (Some (concat nl (concat_map block' t))) in
-      elt Block name attr (Some (concat nl (concat_map li blocks)))
+      elt Block name attr (Some (concat nl (concat_map li bl)))
   | Code_block (label, code) ->
       let code_attr =
         if String.trim label = "" then []

--- a/src/html.mli
+++ b/src/html.mli
@@ -5,7 +5,7 @@ type element_type =
   | Block
 
 type t =
-  | Element of element_type * string * attribute list * t option
+  | Element of element_type * string * attributes * t option
   | Text of string
   | Raw of string
   | Null

--- a/src/html.mli
+++ b/src/html.mli
@@ -11,7 +11,7 @@ type t =
   | Null
   | Concat of t * t
 
-val of_doc : Block.t list -> t
+val of_doc : block list -> t
 
 val to_string : t -> string
 

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -2,12 +2,12 @@ module Pre = Block.Pre
 
 include Ast
 
-type t = Block.t list
+type doc = block list
 
 let parse_inline defs s =
   Parser.inline defs (Parser.P.of_string s)
 
-let parse_inlines (md : Raw.t list) =
+let parse_inlines md =
   let defs =
     let f (def, attr) = {def with label = Parser.normalize def.label}, attr in
     List.map f (Raw.defs md)

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -4,11 +4,13 @@ include Ast
 
 type t = Block.t list
 
+let parse_inline defs s =
+  Parser.inline defs (Parser.P.of_string s)
+
 let parse_inlines (md : Raw.t list) =
-  let parse_inline defs s = Parser.inline defs (Parser.P.of_string s) in
-  let defs = Raw.defs md in
   let defs =
-    List.map (fun (def: string link_def) -> {def with label = Parser.normalize def.label}) defs
+    let f (def, attr) = {def with label = Parser.normalize def.label}, attr in
+    List.map f (Raw.defs md)
   in
   List.map (Mapper.map (parse_inline defs)) md
 

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -51,12 +51,6 @@ module Block : sig
       blocks: t list list;
     }
 
-  and heading =
-    {
-      level: int;
-      text: Inline.t;
-    }
-
   and def_elt =
     {
       term: Inline.t;
@@ -79,7 +73,7 @@ module Block : sig
     | List of block_list
     | Blockquote of t list
     | Thematic_break
-    | Heading of heading
+    | Heading of int * Inline.t
     | Code_block of string * string
     | Html_block of string
     | Link_def of string link_def

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -11,12 +11,7 @@ type 'a link_def =
   }
 
 module Inline : sig
-  type code =
-    {
-      content: string;
-    }
-
-  and t =
+  type t =
     {
       il_desc: t_desc;
       il_attributes: attributes;
@@ -27,7 +22,7 @@ module Inline : sig
     | Text of string
     | Emph of t
     | Strong of t
-    | Code of code
+    | Code of string
     | Hard_break
     | Soft_break
     | Link of t link_def

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -51,12 +51,6 @@ module Block : sig
       blocks: t list list;
     }
 
-  and code_block =
-    {
-      label: string;
-      code: string;
-    }
-
   and heading =
     {
       level: int;
@@ -86,7 +80,7 @@ module Block : sig
     | Blockquote of t list
     | Thematic_break
     | Heading of heading
-    | Code_block of code_block
+    | Code_block of string * string
     | Html_block of string
     | Link_def of string link_def
     | Def_list of def_list

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -35,23 +35,16 @@ module Inline : sig
     | Html of string
 end
 
-type block_list_kind =
+type list_type =
   | Ordered of int * char
-  | Unordered of char
+  | Bullet of char
 
-type block_list_style =
+type list_spacing =
   | Loose
   | Tight
 
 module Block : sig
-  type block_list =
-    {
-      kind: block_list_kind;
-      style: block_list_style;
-      blocks: t list list;
-    }
-
-  and def_elt =
+  type def_elt =
     {
       term: Inline.t;
       defs: Inline.t list;
@@ -70,7 +63,7 @@ module Block : sig
 
   and t_desc =
     | Paragraph of Inline.t
-    | List of block_list
+    | List of list_type * list_spacing * t list list
     | Blockquote of t list
     | Thematic_break
     | Heading of int * Inline.t

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -39,10 +39,6 @@ type block_list_style =
   | Loose
   | Tight
 
-type code_block_kind =
-  | Tilde
-  | Backtick
-
 module Block : sig
   type block_list =
     {
@@ -53,9 +49,7 @@ module Block : sig
 
   and code_block =
     {
-      kind: code_block_kind option;
       label: string option;
-      other: string option;
       code: string option;
       attributes: attribute list;
     }

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -11,21 +11,11 @@ type 'a link_def =
     attributes: attribute list;
   }
 
-type link_kind =
-  | Img
-  | Url
-
 module Inline : sig
   type code =
     {
       content: string;
       attributes: attribute list;
-    }
-
-  and link =
-    {
-      kind: link_kind;
-      def: t link_def;
     }
 
   and t =
@@ -36,7 +26,8 @@ module Inline : sig
     | Code of code
     | Hard_break
     | Soft_break
-    | Link of link
+    | Link of t link_def
+    | Image of t link_def
     | Html of string
 end
 

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -10,25 +10,23 @@ type 'a link_def =
     title: string option;
   }
 
-module Inline : sig
-  type t =
-    {
-      il_desc: t_desc;
-      il_attributes: attributes;
-    }
+type inline =
+  {
+    il_desc: inline_desc;
+    il_attributes: attributes;
+  }
 
-  and t_desc =
-    | Concat of t list
-    | Text of string
-    | Emph of t
-    | Strong of t
-    | Code of string
-    | Hard_break
-    | Soft_break
-    | Link of t link_def
-    | Image of t link_def
-    | Html of string
-end
+and inline_desc =
+  | Concat of inline list
+  | Text of string
+  | Emph of inline
+  | Strong of inline
+  | Code of string
+  | Hard_break
+  | Soft_break
+  | Link of inline link_def
+  | Image of inline link_def
+  | Html of string
 
 type list_type =
   | Ordered of int * char
@@ -38,43 +36,41 @@ type list_spacing =
   | Loose
   | Tight
 
-module Block : sig
-  type def_elt =
-    {
-      term: Inline.t;
-      defs: Inline.t list;
-    }
+type def_elt =
+  {
+    term: inline;
+    defs: inline list;
+  }
 
-  and def_list =
-    {
-      content: def_elt list
-    }
+and def_list =
+  {
+    content: def_elt list
+  }
 
-  and t =
-    {
-      bl_desc: t_desc;
-      bl_attributes: attributes;
-    }
+and block =
+  {
+    bl_desc: block_desc;
+    bl_attributes: attributes;
+  }
 
-  and t_desc =
-    | Paragraph of Inline.t
-    | List of list_type * list_spacing * t list list
-    | Blockquote of t list
-    | Thematic_break
-    | Heading of int * Inline.t
-    | Code_block of string * string
-    | Html_block of string
-    | Link_def of string link_def
-    | Def_list of def_list
-end
+and block_desc =
+  | Paragraph of inline
+  | List of list_type * list_spacing * block list list
+  | Blockquote of block list
+  | Thematic_break
+  | Heading of int * inline
+  | Code_block of string * string
+  | Html_block of string
+  | Link_def of string link_def
+  | Def_list of def_list
 
-type t = Block.t list
+type doc = block list
 (** A markdown document *)
 
-val of_channel: in_channel -> t
+val of_channel: in_channel -> doc
 
-val of_string: string -> t
+val of_string: string -> doc
 
-val to_html: t -> string
+val to_html: doc -> string
 
-val to_sexp: t -> string
+val to_sexp: doc -> string

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -42,11 +42,6 @@ type def_elt =
     defs: inline list;
   }
 
-and def_list =
-  {
-    content: def_elt list
-  }
-
 and block =
   {
     bl_desc: block_desc;
@@ -62,7 +57,7 @@ and block_desc =
   | Code_block of string * string
   | Html_block of string
   | Link_def of string link_def
-  | Def_list of def_list
+  | Definition_list of def_elt list
 
 type doc = block list
 (** A markdown document *)

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -28,13 +28,6 @@ module Inline : sig
       def: t link_def;
     }
 
-  and ref =
-    {
-      kind: link_kind;
-      label: t;
-      def: string link_def;
-    }
-
   and t =
     | Concat of t list
     | Text of string
@@ -44,7 +37,6 @@ module Inline : sig
     | Hard_break
     | Soft_break
     | Link of link
-    | Ref of ref
     | Html of string
 end
 

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -18,7 +18,6 @@ type link_kind =
 module Inline : sig
   type code =
     {
-      level: int;
       content: string;
       attributes: attribute list;
     }

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -49,8 +49,8 @@ module Block : sig
 
   and code_block =
     {
-      label: string option;
-      code: string option;
+      label: string;
+      code: string;
       attributes: attribute list;
     }
 

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -1,24 +1,28 @@
 (** A markdown parser in OCaml. *)
 
-type attribute =
-  string * string
+type attributes =
+  (string * string) list
 
 type 'a link_def =
   {
     label: 'a;
     destination: string;
     title: string option;
-    attributes: attribute list;
   }
 
 module Inline : sig
   type code =
     {
       content: string;
-      attributes: attribute list;
     }
 
   and t =
+    {
+      il_desc: t_desc;
+      il_attributes: attributes;
+    }
+
+  and t_desc =
     | Concat of t list
     | Text of string
     | Emph of t
@@ -51,14 +55,12 @@ module Block : sig
     {
       label: string;
       code: string;
-      attributes: attribute list;
     }
 
   and heading =
     {
       level: int;
       text: Inline.t;
-      attributes: attribute list;
     }
 
   and def_elt =
@@ -73,6 +75,12 @@ module Block : sig
     }
 
   and t =
+    {
+      bl_desc: t_desc;
+      bl_attributes: attributes;
+    }
+
+  and t_desc =
     | Paragraph of Inline.t
     | List of block_list
     | Blockquote of t list

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -19,14 +19,9 @@ type emph_kind =
   | Normal
   | Strong
 
-type emph_style =
-  | Star
-  | Underscore
-
 module Inline : sig
   type emph =
     {
-      style: emph_style;
       kind: emph_kind;
       content: t;
     }

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -15,18 +15,8 @@ type link_kind =
   | Img
   | Url
 
-type emph_kind =
-  | Normal
-  | Strong
-
 module Inline : sig
-  type emph =
-    {
-      kind: emph_kind;
-      content: t;
-    }
-
-  and code =
+  type code =
     {
       level: int;
       content: string;
@@ -49,7 +39,8 @@ module Inline : sig
   and t =
     | Concat of t list
     | Text of string
-    | Emph of emph
+    | Emph of t
+    | Strong of t
     | Code of code
     | Hard_break
     | Soft_break

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1037,8 +1037,11 @@ module Pre = struct
                 if n2 > 1 then Emph (Punct, post, q2, n2-1) :: xs else xs
               in
               let r =
-                let kind = if n1 >= 2 && n2 >= 2 then Strong else Normal in
-                R (Emph {kind; content = concat (List.map to_r (parse_emph (List.rev acc)))}) :: xs
+                let il = concat (List.map to_r (parse_emph (List.rev acc))) in
+                if n1 >= 2 && n2 >= 2 then
+                  R (Strong il) :: xs
+                else
+                  R (Emph il) :: xs
               in
               let r =
                 if n1 >= 2 && n2 >= 2 then

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -970,6 +970,10 @@ module Pre = struct
     | Punct
     | Other
 
+  type emph_style =
+    | Star
+    | Underscore
+
   type t =
     | Bang_left_bracket
     | Left_bracket of link_kind
@@ -1034,7 +1038,7 @@ module Pre = struct
               in
               let r =
                 let kind = if n1 >= 2 && n2 >= 2 then Strong else Normal in
-                R (Emph {kind; style = q1; content = concat (List.map to_r (parse_emph (List.rev acc)))}) :: xs
+                R (Emph {kind; content = concat (List.map to_r (parse_emph (List.rev acc)))}) :: xs
               in
               let r =
                 if n1 >= 2 && n2 >= 2 then
@@ -1785,7 +1789,7 @@ let rec inline defs st =
         let f post n st =
           let pre = pre |> Pre.classify_delim in
           let post = post |> Pre.classify_delim in
-          let e = if c = '*' then Star else Underscore in
+          let e = if c = '*' then Pre.Star else Pre.Underscore in
           loop (Pre.Emph (pre, post, e, n) :: text acc) st
         in
         let rec aux n =

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -259,6 +259,10 @@ type html_kind =
   | Hcontains of string list
   | Hblank
 
+type code_block_kind =
+  | Tilde
+  | Backtick
+
 type t =
   | Lempty
   | Lblockquote of Sub.t

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -272,7 +272,7 @@ type t =
   | Lfenced_code of int * int * code_block_kind * (string * string) * attributes
   | Lindented_code of Sub.t
   | Lhtml of bool * html_kind
-  | Llist_item of block_list_kind * int * Sub.t
+  | Llist_item of list_type * int * Sub.t
   | Lparagraph
   | Ldef_list of string
 
@@ -585,12 +585,12 @@ let unordered_list_item ind s =
   | Some ('+' | '-' | '*' as c) ->
       let s = Sub.tail s in
       if is_empty s then
-        Llist_item (Unordered c, 2 + ind, s)
+        Llist_item (Bullet c, 2 + ind, s)
       else
         let n = indent s in
         if n = 0 then raise Fail;
         let n = if n <= 4 then n else 1 in
-        Llist_item (Unordered c, n + 1 + ind, Sub.offset n s)
+        Llist_item (Bullet c, n + 1 + ind, Sub.offset n s)
   | Some _ | None ->
       raise Fail
 

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -969,7 +969,7 @@ let entity buf st =
       Buffer.add_string buf (range st p (pos st - p))
 
 let mk ?(attr = []) desc =
-  {Ast.Inline.il_desc = desc; il_attributes = attr}
+  {Ast.il_desc = desc; il_attributes = attr}
 
 module Pre = struct
   type delim =
@@ -989,11 +989,11 @@ module Pre = struct
     | Bang_left_bracket
     | Left_bracket of link_kind
     | Emph of delim * delim * emph_style * int
-    | R of Inline.t
+    | R of inline
 
   let concat = function
     | [x] -> x
-    | l -> mk (Inline.Concat l)
+    | l -> mk (Concat l)
 
   let left_flanking = function
     | Emph (_, Other, _, _) | Emph ((Ws | Punct), Punct, _, _) -> true
@@ -1030,7 +1030,7 @@ module Pre = struct
     | _ -> Other
 
   let to_r = function
-    | Bang_left_bracket -> mk (Inline.Text "![")
+    | Bang_left_bracket -> mk (Text "![")
     | Left_bracket Img -> mk (Text "![")
     | Left_bracket Url -> mk (Text "[")
     | Emph (_, _, Star, n) -> mk (Text (String.make n '*'))
@@ -1596,7 +1596,7 @@ let rec inline defs st =
           | Some (def, attr) ->
               let r =
                 let def = {def with label = lab1} in
-                match kind with Pre.Img -> Inline.Image def | Url -> Link def
+                match kind with Pre.Img -> Image def | Url -> Link def
               in
               loop (Pre.R (mk ~attr r) :: text acc) st
           | None ->
@@ -1635,7 +1635,7 @@ let rec inline defs st =
     | '<' as c ->
         begin match protect autolink st with
         | def ->
-            let def = {def with label = mk (Inline.Text def.label)} in
+            let def = {def with label = mk (Text def.label)} in
             let attr = inline_attribute_string st in
             loop (Pre.R (mk ~attr (Link def)) :: text acc) st
         | exception Fail ->
@@ -1761,7 +1761,7 @@ let rec inline defs st =
                         let label = Pre.parse_emph xs in
                         let def = {label; destination; title} in
                         match k with
-                        | Img -> Inline.Image def
+                        | Img -> Image def
                         | Url -> Link def
                       in
                       let attr = inline_attribute_string st in
@@ -1778,7 +1778,7 @@ let rec inline defs st =
                       begin match List.find_opt (fun ({label; _}, _) -> label = s) defs with
                       | Some (def, attr) ->
                           let def = {def with label} in
-                          let r = match k with Img -> Inline.Image def | Url -> Link def in
+                          let r = match k with Img -> Image def | Url -> Link def in
                           loop (Pre.R (mk ~attr r) :: acc') st
                       | None ->
                           if k = Img then Buffer.add_char buf '!';

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1670,8 +1670,7 @@ let rec inline defs st =
                   else
                     content
                 in
-                loop (Pre.R (Code {level = n;
-                                   content;
+                loop (Pre.R (Code {content;
                                    attributes = inline_attribute_string st}) :: acc) st
               in
               let rec loop3 start m =

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1688,7 +1688,7 @@ let rec inline defs st =
                     content
                 in
                 let attr = inline_attribute_string st in
-                loop (Pre.R (mk ~attr (Code {content})) :: acc) st
+                loop (Pre.R (mk ~attr (Code content)) :: acc) st
               in
               let rec loop3 start m =
                 match peek st with

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1583,7 +1583,7 @@ let rec inline defs st =
           let s = normalize lab' in
           match List.find_opt (fun ({label; _}: string link_def) -> label = s) defs with
           | Some def ->
-              loop (Pre.R (Ref {kind; label = lab1; def}) :: text acc) st
+              loop (Pre.R (Link {kind; def = {def with label = lab1}}) :: text acc) st
           | None ->
               if kind = Img then Buffer.add_char buf '!';
               Buffer.add_char buf '[';
@@ -1756,7 +1756,7 @@ let rec inline defs st =
                       let s = normalize lab in
                       begin match List.find_opt (fun ({label; _}: string link_def) -> label = s) defs with
                       | Some def ->
-                          loop (Pre.R (Ref {kind = k; label; def}) :: acc') st
+                          loop (Pre.R (Link {kind = k; def = {def with label}}) :: acc') st
                       | None ->
                           if k = Img then Buffer.add_char buf '!';
                           Buffer.add_char buf '[';
@@ -1776,7 +1776,7 @@ let rec inline defs st =
               | Some _ | None ->
                   Buffer.add_char buf ']'; loop acc st
               end
-          | Pre.R (Link {kind = Url; _} | Ref {kind = Url; _}) as x :: acc' ->
+          | Pre.R (Link {kind = Url; _}) as x :: acc' ->
               aux true (x :: xs) acc'
           | x :: acc' ->
               aux seen_link (x :: xs) acc'

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -44,10 +44,8 @@ let rec block = function
       Atom "thematic-break"
   | Heading {level; text; _} ->
       List [Atom "heading"; Atom (string_of_int level); inline text]
-  | Code_block {code = Some s; _} ->
-      List [Atom "code-block"; Atom s]
-  | Code_block {code = None; _} ->
-      List [Atom "code-block"]
+  | Code_block {code; _} ->
+      List [Atom "code-block"; Atom code]
   | Html_block s ->
       List [Atom "html"; Atom s]
   | Link_def {label; destination; _} ->

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -44,14 +44,10 @@ let rec block = function
       Atom "thematic-break"
   | Heading {level; text; _} ->
       List [Atom "heading"; Atom (string_of_int level); inline text]
-  | Code_block {kind = None; code = Some s; _} ->
-      List [Atom "indented-code"; Atom s]
-  | Code_block {kind = None; code = None; _} ->
-      List [Atom "indented-code"]
-  | Code_block {kind = Some _; code = Some s; _} ->
-      List [Atom "fenced-code"; Atom s]
-  | Code_block {kind = Some _; code = None; _} ->
-      List [Atom "fenced-code"]
+  | Code_block {code = Some s; _} ->
+      List [Atom "code-block"; Atom s]
+  | Code_block {code = None; _} ->
+      List [Atom "code-block"]
   | Html_block s ->
       List [Atom "html"; Atom s]
   | Link_def {label; destination; _} ->

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -11,9 +11,9 @@ let rec link_def : 'a. ('a -> t) -> 'a link_def -> t =
     let title = match title with Some title -> [Atom title] | None -> [] in
     List (Atom "link-def" :: f label :: Atom destination :: title)
 
-and inline {Inline.il_desc; _} =
+and inline {il_desc; _} =
   match il_desc with
-  | Inline.Concat xs ->
+  | Concat xs ->
       List (Atom "concat" :: List.map inline xs)
   | Text s ->
       Atom s
@@ -34,9 +34,9 @@ and inline {Inline.il_desc; _} =
   | Image _ ->
       Atom "img"
 
-let rec block {Block.bl_desc; bl_attributes = _} =
+let rec block {bl_desc; bl_attributes = _} =
   match bl_desc with
-  | Block.Paragraph x ->
+  | Paragraph x ->
       List [Atom "paragraph"; inline x]
   | List (_, _, bls) ->
       List (Atom "list" :: List.map (fun xs -> List (Atom "list-item" :: List.map block xs)) bls)
@@ -54,7 +54,7 @@ let rec block {Block.bl_desc; bl_attributes = _} =
       List [Atom "link-def"; Atom label; Atom destination]
   | Def_list {content} ->
       List [Atom "def-list";
-            List (List.map (fun elt -> List [inline elt.Block.term;
+            List (List.map (fun elt -> List [inline elt.term;
                                              List (List.map inline elt.defs)]) content)]
 
 let create ast =

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -38,8 +38,8 @@ let rec block {Block.bl_desc; bl_attributes = _} =
   match bl_desc with
   | Block.Paragraph x ->
       List [Atom "paragraph"; inline x]
-  | List l ->
-      List (Atom "list" :: List.map (fun xs -> List (Atom "list-item" :: List.map block xs)) l.blocks)
+  | List (_, _, bls) ->
+      List (Atom "list" :: List.map (fun xs -> List (Atom "list-item" :: List.map block xs)) bls)
   | Blockquote xs ->
       List (Atom "blockquote" :: List.map block xs)
   | Thematic_break ->

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -52,10 +52,11 @@ let rec block {bl_desc; bl_attributes = _} =
       List [Atom "html"; Atom s]
   | Link_def {label; destination; _} ->
       List [Atom "link-def"; Atom label; Atom destination]
-  | Def_list {content} ->
+  | Definition_list l ->
       List [Atom "def-list";
-            List (List.map (fun elt -> List [inline elt.term;
-                                             List (List.map inline elt.defs)]) content)]
+            List (List.map (fun elt ->
+                List [inline elt.term;
+                      List (List.map inline elt.defs)]) l)]
 
 let create ast =
   List (List.map block ast)

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -26,11 +26,11 @@ and inline = function
       Atom "hard-break"
   | Soft_break ->
       Atom "soft-break"
-  | Link {kind = Url; def; _} ->
+  | Link def ->
       List [Atom "url"; link_def inline def]
   | Html s ->
       List [Atom "html"; Atom s]
-  | Link {kind = Img; _} ->
+  | Image _ ->
       Atom "img"
 
 let rec block = function

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -46,8 +46,8 @@ let rec block {Block.bl_desc; bl_attributes = _} =
       Atom "thematic-break"
   | Heading {level; text; _} ->
       List [Atom "heading"; Atom (string_of_int level); inline text]
-  | Code_block {code; _} ->
-      List [Atom "code-block"; Atom code]
+  | Code_block (info, _) ->
+      List [Atom "code-block"; Atom info]
   | Html_block s ->
       List [Atom "html"; Atom s]
   | Link_def {label; destination; _} ->

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -16,8 +16,10 @@ and inline = function
       List (Atom "concat" :: List.map inline xs)
   | Text s ->
       Atom s
-  | Emph e ->
-      List [Atom "emph"; inline e.content]
+  | Emph il ->
+      List [Atom "emph"; inline il]
+  | Strong il ->
+      List [Atom "strong"; inline il]
   | Code _ ->
       Atom "code"
   | Hard_break ->

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -44,7 +44,7 @@ let rec block {Block.bl_desc; bl_attributes = _} =
       List (Atom "blockquote" :: List.map block xs)
   | Thematic_break ->
       Atom "thematic-break"
-  | Heading {level; text; _} ->
+  | Heading (level, text) ->
       List [Atom "heading"; Atom (string_of_int level); inline text]
   | Code_block (info, _) ->
       List [Atom "code-block"; Atom info]

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -11,7 +11,8 @@ let rec link_def : 'a. ('a -> t) -> 'a link_def -> t =
     let title = match title with Some title -> [Atom title] | None -> [] in
     List (Atom "link-def" :: f label :: Atom destination :: title)
 
-and inline = function
+and inline {Inline.il_desc; _} =
+  match il_desc with
   | Inline.Concat xs ->
       List (Atom "concat" :: List.map inline xs)
   | Text s ->
@@ -33,7 +34,8 @@ and inline = function
   | Image _ ->
       Atom "img"
 
-let rec block = function
+let rec block {Block.bl_desc; bl_attributes = _} =
+  match bl_desc with
   | Block.Paragraph x ->
       List [Atom "paragraph"; inline x]
   | List l ->

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -28,14 +28,10 @@ and inline = function
       Atom "soft-break"
   | Link {kind = Url; def; _} ->
       List [Atom "url"; link_def inline def]
-  | Ref {kind = Url; label; def; _} ->
-      List [Atom "url-ref"; inline label; link_def atom def]
   | Html s ->
       List [Atom "html"; Atom s]
   | Link {kind = Img; _} ->
       Atom "img"
-  | Ref {kind = Img; label; def; _} ->
-      List [Atom "img-ref"; inline label; link_def atom def]
 
 let rec block = function
   | Block.Paragraph x ->


### PR DESCRIPTION
Various clean ups of the AST.

- Attach attributes generically to AST nodes
- Get rid of various auxiliary record types
- Get rid of fields in the AST nodes not relevant for conversion into other formats