### PR TITLE
Get rid of Link_def node

### DIFF
--- a/src/block.mli
+++ b/src/block.mli
@@ -1,10 +1,4 @@
 module Pre : sig
-  type t
-
-  val empty: t
-  val process: t -> string -> t
-  val finish: t -> Ast.Raw.block list
-
-  val of_channel: in_channel -> Ast.Raw.block list
-  val of_string: string -> Ast.Raw.block list
+  val of_channel: in_channel -> Ast.Raw.block list * Ast.link_def list
+  val of_string: string -> Ast.Raw.block list * Ast.link_def list
 end

--- a/src/html.ml
+++ b/src/html.ml
@@ -200,8 +200,6 @@ let rec block {bl_desc; bl_attributes = attr} =
           (concat_map (fun s -> elt Block "dd" [] (Some (inline s))) defs)
       in
       elt Block "dl" attr (Some (concat_map f l))
-  | Link_def _ ->
-      Null
 
 let of_doc doc =
   concat_map block doc

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -7,20 +7,18 @@ type doc = block list
 let parse_inline defs s =
   Parser.inline defs (Parser.P.of_string s)
 
-let parse_inlines md =
+let parse_inlines (md, defs) =
   let defs =
-    let f (def, attr) = {def with label = Parser.normalize def.label}, attr in
-    List.map f (Raw.defs md)
+    let f (def : link_def) = {def with label = Parser.normalize def.label} in
+    List.map f defs
   in
   List.map (Mapper.map (parse_inline defs)) md
 
 let of_channel ic =
-  let md = Pre.of_channel ic in
-  parse_inlines md
+  parse_inlines (Pre.of_channel ic)
 
 let of_string s =
-  let md = Pre.of_string s in
-  parse_inlines md
+  parse_inlines (Pre.of_string s)
 
 let to_html doc =
   Html.to_string (Html.of_doc doc)

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -3,14 +3,14 @@
 type attributes =
   (string * string) list
 
-type 'a link_def =
+type link =
   {
-    label: 'a;
+    label: inline;
     destination: string;
     title: string option;
   }
 
-type inline =
+and inline =
   {
     il_desc: inline_desc;
     il_attributes: attributes;
@@ -24,8 +24,8 @@ and inline_desc =
   | Code of string
   | Hard_break
   | Soft_break
-  | Link of inline link_def
-  | Image of inline link_def
+  | Link of link
+  | Image of link
   | Html of string
 
 type list_type =
@@ -56,7 +56,6 @@ and block_desc =
   | Heading of int * inline
   | Code_block of string * string
   | Html_block of string
-  | Link_def of string link_def
   | Definition_list of def_elt list
 
 type doc = block list

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -6,10 +6,9 @@ type t =
 
 let atom s = Atom s
 
-let rec link_def : 'a. ('a -> t) -> 'a link_def -> t =
-  fun f {label; destination; title; _} ->
-    let title = match title with Some title -> [Atom title] | None -> [] in
-    List (Atom "link-def" :: f label :: Atom destination :: title)
+let rec link {label; destination; title; _} =
+  let title = match title with Some title -> [Atom title] | None -> [] in
+  List (Atom "link" :: inline label :: Atom destination :: title)
 
 and inline {il_desc; _} =
   match il_desc with
@@ -28,7 +27,7 @@ and inline {il_desc; _} =
   | Soft_break ->
       Atom "soft-break"
   | Link def ->
-      List [Atom "url"; link_def inline def]
+      List [Atom "url"; link def]
   | Html s ->
       List [Atom "html"; Atom s]
   | Image _ ->
@@ -50,8 +49,6 @@ let rec block {bl_desc; bl_attributes = _} =
       List [Atom "code-block"; Atom info]
   | Html_block s ->
       List [Atom "html"; Atom s]
-  | Link_def {label; destination; _} ->
-      List [Atom "link-def"; Atom label; Atom destination]
   | Definition_list l ->
       List [Atom "def-list";
             List (List.map (fun elt ->


### PR DESCRIPTION
As [observed](https://github.com/ocaml/omd/issues/216#issuecomment-653841374) by @shonfeder, the `Link_def` node is no longer useful in the AST. Let's remove it.