### PR TITLE
dune-project: add lower bound on ocaml

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -21,4 +21,5 @@ OMD is meant to be as faithful as possible to the original Markdown.
 Additionally, OMD implements a few Github markdown features, an
 extension mechanism, and some other features. Note that the opam
 package installs both the OMD library and the command line tool `omd`.")
- (tags (org:ocamllabs org:mirage)))
+ (tags (org:ocamllabs org:mirage))
+ (depends (ocaml (>= 4.04))))

--- a/omd.opam
+++ b/omd.opam
@@ -20,6 +20,7 @@ homepage: "https://github.com/ocaml/omd"
 bug-reports: "https://github.com/ocaml/omd/issues"
 depends: [
   "dune" {>= "2.5"}
+  "ocaml" {>= "4.04"}
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
The code uses String.split_on_char which was introduced in 4.04.
Should I also regenerate the opam file?