### PR TITLE
AST representation changes

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -9,105 +9,96 @@ type list_spacing =
   | Loose
   | Tight
 
-let same_block_list_kind k1 k2 =
-  match k1, k2 with
-  | Ordered (_, c1), Ordered (_, c2)
-  | Bullet c1, Bullet c2 -> c1 = c2
-  | _ -> false
-
-type link_def =
+type 'attr link_def =
   {
     label: string;
     destination: string;
     title: string option;
-    attributes: attributes;
+    attributes: 'attr;
   }
 
 module type T = sig
-  type t
+  type 'a t
 end
 
-module MakeBlock (I : T) = struct
-  type def_elt =
+module MakeBlock(I : T) = struct
+  type 'attr def_elt =
     {
-      term: I.t;
-      defs: I.t list;
+      term: 'attr I.t;
+      defs: 'attr I.t list;
     }
 
-  and block =
-    {
-      bl_desc: block_desc;
-      bl_attributes: attributes;
-    }
-
-  and block_desc =
-    | Paragraph of I.t
-    | List of list_type * list_spacing * block list list
-    | Blockquote of block list
-    | Thematic_break
-    | Heading of int * I.t
-    | Code_block of string * string
-    | Html_block of string
-    | Definition_list of def_elt list
+  (* A value of type 'attr is present in all variants of this type. We use it to associate
+     extra information to each node in the AST. In the common case, the attributes type defined
+     above is used. We might eventually have an alternative function to parse blocks while keeping
+     concrete information such as source location and we'll use it for that as well. *)
+  type 'attr block =
+    | Paragraph of 'attr * 'attr I.t
+    | List of 'attr * list_type * list_spacing * 'attr block list list
+    | Blockquote of 'attr * 'attr block list
+    | Thematic_break of 'attr
+    | Heading of 'attr * int * 'attr I.t
+    | Code_block of 'attr * string * string
+    | Html_block of 'attr * string
+    | Definition_list of 'attr * 'attr def_elt list
 end
 
-type link =
+type 'attr link =
   {
-    label: inline;
+    label: 'attr inline;
     destination: string;
     title: string option;
   }
 
-and inline =
-  {
-    il_desc: inline_desc;
-    il_attributes: attributes;
-  }
+(* See comment on the block type above about the 'attr parameter *)
+and 'attr inline =
+  | Concat of 'attr * 'attr inline list
+  | Text of 'attr * string
+  | Emph of 'attr * 'attr inline
+  | Strong of 'attr * 'attr inline
+  | Code of 'attr * string
+  | Hard_break of 'attr
+  | Soft_break of 'attr
+  | Link of 'attr * 'attr link
+  | Image of 'attr * 'attr link
+  | Html of 'attr * string
 
-and inline_desc =
-  | Concat of inline list
-  | Text of string
-  | Emph of inline
-  | Strong of inline
-  | Code of string
-  | Hard_break
-  | Soft_break
-  | Link of link
-  | Image of link
-  | Html of string
+module StringT = struct type 'attr t = string end
+module InlineT = struct type 'attr t = 'attr inline end
 
-module Raw = MakeBlock (String)
+module Raw = MakeBlock(StringT)
+module Inline = MakeBlock(InlineT)
 
-module Inline = struct type t = inline end
-
-include MakeBlock (Inline)
+include Inline
 
 module MakeMapper (Src : T) (Dst : T) = struct
   module SrcBlock = MakeBlock(Src)
   module DstBlock = MakeBlock(Dst)
 
-  let rec map (f : Src.t -> Dst.t) : SrcBlock.block -> DstBlock.block =
-    fun {bl_desc; bl_attributes} ->
-    let bl_desc =
-      match bl_desc with
-      | SrcBlock.Paragraph x -> DstBlock.Paragraph (f x)
-      | List (ty, sp, bl) ->
-          List (ty, sp, List.map (List.map (map f)) bl)
-      | Blockquote xs ->
-          Blockquote (List.map (map f) xs)
-      | Thematic_break ->
-          Thematic_break
-      | Heading (level, text) ->
-          Heading (level, f text)
-      | Definition_list l ->
+  let rec map (f : 'attr Src.t -> 'attr Dst.t) : 'attr SrcBlock.block -> 'attr DstBlock.block =
+    function
+      | SrcBlock.Paragraph (attr, x) -> DstBlock.Paragraph (attr, f x)
+      | List (attr, ty, sp, bl) ->
+          List (attr, ty, sp, List.map (List.map (map f)) bl)
+      | Blockquote (attr, xs) ->
+          Blockquote (attr, List.map (map f) xs)
+      | Thematic_break attr ->
+          Thematic_break attr
+      | Heading (attr, level, text) ->
+          Heading (attr, level, f text)
+      | Definition_list (attr, l) ->
           let f {SrcBlock.term; defs} = {DstBlock.term = f term; defs = List.map f defs} in
-          Definition_list (List.map f l)
-      | Code_block (label, code) ->
-          Code_block (label, code)
-      | Html_block x ->
-          Html_block x
-    in
-    {bl_desc; bl_attributes}
+          Definition_list (attr, List.map f l)
+      | Code_block (attr, label, code) ->
+          Code_block (attr, label, code)
+      | Html_block (attr, x) ->
+          Html_block (attr, x)
 end
 
-module Mapper = MakeMapper (String) (Inline)
+module Mapper = MakeMapper (StringT) (InlineT)
+
+let same_block_list_kind k1 k2 =
+  match k1, k2 with
+  | Ordered (_, c1), Ordered (_, c2)
+  | Bullet c1, Bullet c2 -> c1 = c2
+  | _ -> false

--- a/src/block.mli
+++ b/src/block.mli
@@ -1,4 +1,7 @@
+open Ast
+
 module Pre : sig
-  val of_channel: in_channel -> Ast.Raw.block list * Ast.link_def list
-  val of_string: string -> Ast.Raw.block list * Ast.link_def list
+
+  val of_channel: in_channel -> attributes Raw.block list * attributes link_def list
+  val of_string: string -> attributes Raw.block list * attributes link_def list
 end

--- a/src/html.mli
+++ b/src/html.mli
@@ -11,7 +11,7 @@ type t =
   | Null
   | Concat of t * t
 
-val of_doc : block list -> t
+val of_doc : attributes block list -> t
 
 val to_string : t -> string
 

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -2,14 +2,14 @@ module Pre = Block.Pre
 
 include Ast
 
-type doc = block list
+type doc = attributes block list
 
 let parse_inline defs s =
   Parser.inline defs (Parser.P.of_string s)
 
 let parse_inlines (md, defs) =
   let defs =
-    let f (def : link_def) = {def with label = Parser.normalize def.label} in
+    let f (def : attributes link_def) = {def with label = Parser.normalize def.label} in
     List.map f defs
   in
   List.map (Mapper.map (parse_inline defs)) md

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -3,31 +3,6 @@
 type attributes =
   (string * string) list
 
-type link =
-  {
-    label: inline;
-    destination: string;
-    title: string option;
-  }
-
-and inline =
-  {
-    il_desc: inline_desc;
-    il_attributes: attributes;
-  }
-
-and inline_desc =
-  | Concat of inline list
-  | Text of string
-  | Emph of inline
-  | Strong of inline
-  | Code of string
-  | Hard_break
-  | Soft_break
-  | Link of link
-  | Image of link
-  | Html of string
-
 type list_type =
   | Ordered of int * char
   | Bullet of char
@@ -36,29 +11,43 @@ type list_spacing =
   | Loose
   | Tight
 
-type def_elt =
+type 'attr link =
   {
-    term: inline;
-    defs: inline list;
+    label: 'attr inline;
+    destination: string;
+    title: string option;
   }
 
-and block =
+and 'attr inline =
+  | Concat of 'attr * 'attr inline list
+  | Text of 'attr * string
+  | Emph of 'attr * 'attr inline
+  | Strong of 'attr * 'attr inline
+  | Code of 'attr * string
+  | Hard_break of 'attr
+  | Soft_break of 'attr
+  | Link of 'attr * 'attr link
+  | Image of 'attr * 'attr link
+  | Html of 'attr * string
+
+
+type 'attr def_elt =
   {
-    bl_desc: block_desc;
-    bl_attributes: attributes;
+    term: 'attr inline;
+    defs: 'attr inline list;
   }
 
-and block_desc =
-  | Paragraph of inline
-  | List of list_type * list_spacing * block list list
-  | Blockquote of block list
-  | Thematic_break
-  | Heading of int * inline
-  | Code_block of string * string
-  | Html_block of string
-  | Definition_list of def_elt list
+type 'attr block =
+  | Paragraph of 'attr * 'attr inline
+  | List of 'attr * list_type * list_spacing * 'attr block list list
+  | Blockquote of 'attr * 'attr block list
+  | Thematic_break of 'attr
+  | Heading of 'attr * int * 'attr inline
+  | Code_block of 'attr * string * string
+  | Html_block of 'attr * string
+  | Definition_list of 'attr * 'attr def_elt list
 
-type doc = block list
+type doc = attributes block list
 (** A markdown document *)
 
 val of_channel: in_channel -> doc

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -10,46 +10,44 @@ let rec link {label; destination; title; _} =
   let title = match title with Some title -> [Atom title] | None -> [] in
   List (Atom "link" :: inline label :: Atom destination :: title)
 
-and inline {il_desc; _} =
-  match il_desc with
-  | Concat xs ->
+and inline = function
+  | Concat (_, xs) ->
       List (Atom "concat" :: List.map inline xs)
-  | Text s ->
+  | Text (_, s) ->
       Atom s
-  | Emph il ->
+  | Emph (_, il) ->
       List [Atom "emph"; inline il]
-  | Strong il ->
+  | Strong (_, il) ->
       List [Atom "strong"; inline il]
   | Code _ ->
       Atom "code"
-  | Hard_break ->
+  | Hard_break _ ->
       Atom "hard-break"
-  | Soft_break ->
+  | Soft_break _->
       Atom "soft-break"
-  | Link def ->
+  | Link (_, def) ->
       List [Atom "url"; link def]
-  | Html s ->
+  | Html (_, s) ->
       List [Atom "html"; Atom s]
   | Image _ ->
       Atom "img"
 
-let rec block {bl_desc; bl_attributes = _} =
-  match bl_desc with
-  | Paragraph x ->
+let rec block = function
+  | Paragraph (_, x) ->
       List [Atom "paragraph"; inline x]
-  | List (_, _, bls) ->
+  | List (_, _, _, bls) ->
       List (Atom "list" :: List.map (fun xs -> List (Atom "list-item" :: List.map block xs)) bls)
-  | Blockquote xs ->
+  | Blockquote (_, xs) ->
       List (Atom "blockquote" :: List.map block xs)
-  | Thematic_break ->
+  | Thematic_break _ ->
       Atom "thematic-break"
-  | Heading (level, text) ->
+  | Heading (_, level, text) ->
       List [Atom "heading"; Atom (string_of_int level); inline text]
-  | Code_block (info, _) ->
+  | Code_block (_, info, _) ->
       List [Atom "code-block"; Atom info]
-  | Html_block s ->
+  | Html_block (_, s) ->
       List [Atom "html"; Atom s]
-  | Definition_list l ->
+  | Definition_list (_, l) ->
       List [Atom "def-list";
             List (List.map (fun elt ->
                 List [inline elt.term;


### PR DESCRIPTION
Opening the PR to continue the discussion started on #228.

Changes to the AST are:

* Remove the record wrapper for each node and inline the attribute field
* Make the block type parametric with the goal of using this flexibility to later have a way to parse and return the AST with source locations and whatever information we might want per node. 