### PR TITLE
Add ocamlformat and update CI pipeline

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,6 +7,25 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Use OCaml
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.12.x
+          dune-cache: true
+      - name: Opam lint
+        run: |
+          opam depext opam-dune-lint --install
+          opam exec -- opam-dune-lint
+      - name: Format lint
+        run: |
+          opam depext ocamlformat=$(grep 'version' .ocamlformat | awk -F '=' '{ print $2 }' | tr -d ' ') --install
+          opam exec -- dune build @fmt
+
   build:
     strategy:
       fail-fast: false
@@ -15,27 +34,22 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-        ocaml-version:
+        ocaml-compiler:
+          # Decision on version matrix informed by https://discuss.ocaml.org/t/which-ocaml-compiler-versions-should-we-run-against-in-ci/7933/2
           - 4.04.2
-          - 4.05.0
-          - 4.06.1
-          - 4.07.1
-          - 4.08.1
-          - 4.09.1
-
+          - 4.12.x
     runs-on: ${{ matrix.os }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-
-      - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v1
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: ${{ matrix.ocaml-version }}
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+      - name: Install deps
+        run: opam install . --deps-only --with-doc --with-test
+      - name: Build
+        run: opam exec -- dune build
 
-      - run: opam install . --deps-only --with-doc --with-test
-
-      - run: opam exec -- dune build
-
-      - run: opam exec -- dune runtest
+      - name: Test
+        run: opam exec -- dune runtest

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,12 @@
+version = 0.18.0
+exp-grouping = preserve
+break-fun-sig = fit-or-vertical
+break-fun-decl = fit-or-vertical
+wrap-fun-args = false
+dock-collection-brackets = false
+break-cases = all
+break-separators = before
+break-infix = fit-or-vertical
+if-then-else = k-r
+nested-match = align
+type-decl = sparse

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 # @file
 
-.PHONY: test build
+.PHONY: test build fmt
 
 build:
 	dune build
@@ -12,4 +12,6 @@ test:
 	-dune build @gen --auto-promote
 	dune test
 
+fmt:
+	-dune build @fmt --auto-promote
 # end

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,14 +1,22 @@
 let with_open_in fn f =
   let ic = open_in fn in
   match f ic with
-  | r -> close_in ic; r
-  | exception e -> close_in_noerr ic; raise e
+  | r ->
+      close_in ic;
+      r
+  | exception e ->
+      close_in_noerr ic;
+      raise e
 
 let with_open_out fn f =
   let oc = open_out fn in
   match f oc with
-  | r -> close_out oc; r
-  | exception e -> close_out_noerr oc; raise e
+  | r ->
+      close_out oc;
+      r
+  | exception e ->
+      close_out_noerr oc;
+      raise e
 
 let process ic oc =
   let md = Omd.of_channel ic in
@@ -19,16 +27,17 @@ let input = ref []
 let output = ref ""
 
 let spec =
-  [
-    "-o", Arg.Set_string output,
-    " file.html Specify the output file (default is stdout).";
-
-    "--", Rest(fun s -> input := s :: !input),
-    " Consider all remaining arguments as input file names.";
+  [ ( "-o"
+    , Arg.Set_string output
+    , " file.html Specify the output file (default is stdout)." )
+  ; ( "--"
+    , Rest (fun s -> input := s :: !input)
+    , " Consider all remaining arguments as input file names." )
   ]
 
 let main () =
-  Arg.parse (Arg.align spec)
+  Arg.parse
+    (Arg.align spec)
     (fun s -> input := s :: !input)
     "omd [options] [inputfile1 .. inputfileN] [options]";
   let with_output f =
@@ -38,16 +47,14 @@ let main () =
       with_open_out !output f
   in
   with_output @@ fun oc ->
-  if !input = [] then process stdin oc
-  else begin
+  if !input = [] then
+    process stdin oc
+  else
     let f filename = with_open_in filename @@ fun ic -> process ic oc in
     List.iter f !input
-  end
 
 let () =
-  try
-    main ()
-  with
+  try main () with
   | Sys_error msg ->
       Printf.eprintf "Error: %s\n" msg;
       exit 1

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -1,5 +1,4 @@
-type attributes =
-  (string * string) list
+type attributes = (string * string) list
 
 type list_type =
   | Ordered of int * char
@@ -10,22 +9,20 @@ type list_spacing =
   | Tight
 
 type 'attr link_def =
-  {
-    label: string;
-    destination: string;
-    title: string option;
-    attributes: 'attr;
+  { label : string
+  ; destination : string
+  ; title : string option
+  ; attributes : 'attr
   }
 
 module type T = sig
   type 'a t
 end
 
-module MakeBlock(I : T) = struct
+module MakeBlock (I : T) = struct
   type 'attr def_elt =
-    {
-      term: 'attr I.t;
-      defs: 'attr I.t list;
+    { term : 'attr I.t
+    ; defs : 'attr I.t list
     }
 
   (* A value of type 'attr is present in all variants of this type. We use it to associate
@@ -44,10 +41,9 @@ module MakeBlock(I : T) = struct
 end
 
 type 'attr link =
-  {
-    label: 'attr inline;
-    destination: string;
-    title: string option;
+  { label : 'attr inline
+  ; destination : string
+  ; title : string option
   }
 
 (* See comment on the block type above about the 'attr parameter *)
@@ -63,42 +59,44 @@ and 'attr inline =
   | Image of 'attr * 'attr link
   | Html of 'attr * string
 
-module StringT = struct type 'attr t = string end
-module InlineT = struct type 'attr t = 'attr inline end
+module StringT = struct
+  type 'attr t = string
+end
 
-module Raw = MakeBlock(StringT)
-module Inline = MakeBlock(InlineT)
+module InlineT = struct
+  type 'attr t = 'attr inline
+end
 
+module Raw = MakeBlock (StringT)
+module Inline = MakeBlock (InlineT)
 include Inline
 
 module MakeMapper (Src : T) (Dst : T) = struct
-  module SrcBlock = MakeBlock(Src)
-  module DstBlock = MakeBlock(Dst)
+  module SrcBlock = MakeBlock (Src)
+  module DstBlock = MakeBlock (Dst)
 
-  let rec map (f : 'attr Src.t -> 'attr Dst.t) : 'attr SrcBlock.block -> 'attr DstBlock.block =
-    function
-      | SrcBlock.Paragraph (attr, x) -> DstBlock.Paragraph (attr, f x)
-      | List (attr, ty, sp, bl) ->
-          List (attr, ty, sp, List.map (List.map (map f)) bl)
-      | Blockquote (attr, xs) ->
-          Blockquote (attr, List.map (map f) xs)
-      | Thematic_break attr ->
-          Thematic_break attr
-      | Heading (attr, level, text) ->
-          Heading (attr, level, f text)
-      | Definition_list (attr, l) ->
-          let f {SrcBlock.term; defs} = {DstBlock.term = f term; defs = List.map f defs} in
-          Definition_list (attr, List.map f l)
-      | Code_block (attr, label, code) ->
-          Code_block (attr, label, code)
-      | Html_block (attr, x) ->
-          Html_block (attr, x)
+  let rec map (f : 'attr Src.t -> 'attr Dst.t) :
+      'attr SrcBlock.block -> 'attr DstBlock.block = function
+    | SrcBlock.Paragraph (attr, x) -> DstBlock.Paragraph (attr, f x)
+    | List (attr, ty, sp, bl) ->
+        List (attr, ty, sp, List.map (List.map (map f)) bl)
+    | Blockquote (attr, xs) -> Blockquote (attr, List.map (map f) xs)
+    | Thematic_break attr -> Thematic_break attr
+    | Heading (attr, level, text) -> Heading (attr, level, f text)
+    | Definition_list (attr, l) ->
+        let f { SrcBlock.term; defs } =
+          { DstBlock.term = f term; defs = List.map f defs }
+        in
+        Definition_list (attr, List.map f l)
+    | Code_block (attr, label, code) -> Code_block (attr, label, code)
+    | Html_block (attr, x) -> Html_block (attr, x)
 end
 
 module Mapper = MakeMapper (StringT) (InlineT)
 
 let same_block_list_kind k1 k2 =
-  match k1, k2 with
+  match (k1, k2) with
   | Ordered (_, c1), Ordered (_, c2)
-  | Bullet c1, Bullet c2 -> c1 = c2
+  | Bullet c1, Bullet c2 ->
+      c1 = c2
   | _ -> false

--- a/src/block.ml
+++ b/src/block.ml
@@ -1,22 +1,32 @@
 open Ast
-
 module Sub = Parser.Sub
 
 module Pre = struct
   type container =
     | Rblockquote of t
-    | Rlist of list_type * list_spacing * bool * int * attributes Raw.block list list * t
+    | Rlist of
+        list_type
+        * list_spacing
+        * bool
+        * int
+        * attributes Raw.block list list
+        * t
     | Rparagraph of string list
-    | Rfenced_code of int * int * Parser.code_block_kind * (string * string) * string list * attributes
+    | Rfenced_code of
+        int
+        * int
+        * Parser.code_block_kind
+        * (string * string)
+        * string list
+        * attributes
     | Rindented_code of string list
     | Rhtml of Parser.html_kind * string list
     | Rdef_list of string * string list
     | Rempty
 
   and t =
-    {
-      blocks: attributes Raw.block list;
-      next: container;
+    { blocks : attributes Raw.block list
+    ; next : container
     }
 
   let concat l = String.concat "\n" (List.rev l) ^ "\n"
@@ -25,30 +35,36 @@ module Pre = struct
     let rec loop i =
       if i >= String.length s then
         i
-      else begin
+      else
         match s.[i] with
-        | ' ' | '\t' ->
+        | ' '
+        | '\t' ->
             loop (succ i)
-        | _ ->
-            i
-      end
+        | _ -> i
     in
     let i = loop 0 in
-    if i > 0 then String.sub s i (String.length s - i) else s
+    if i > 0 then
+      String.sub s i (String.length s - i)
+    else
+      s
 
-  let rec close link_defs {blocks; next} =
+  let rec close link_defs { blocks; next } =
     let finish = finish link_defs in
     match next with
-    | Rblockquote state ->
-        Raw.Blockquote ([], (finish state)) :: blocks
+    | Rblockquote state -> Raw.Blockquote ([], finish state) :: blocks
     | Rlist (ty, sp, _, _, closed_items, state) ->
         List ([], ty, sp, List.rev (finish state :: closed_items)) :: blocks
     | Rparagraph l ->
         let s = concat (List.map trim_left l) in
-        let defs, off = Parser.link_reference_definitions (Parser.P.of_string s) in
+        let defs, off =
+          Parser.link_reference_definitions (Parser.P.of_string s)
+        in
         let s = String.sub s off (String.length s - off) |> String.trim in
         link_defs := defs @ !link_defs;
-        if s = "" then blocks else Paragraph ([], s) :: blocks
+        if s = "" then
+          blocks
+        else
+          Paragraph ([], s) :: blocks
     | Rfenced_code (_, _, _kind, (label, _other), [], attr) ->
         Code_block (attr, label, "") :: blocks
     | Rfenced_code (_, _, _kind, (label, _other), l, attr) ->
@@ -56,69 +72,70 @@ module Pre = struct
     | Rdef_list (term, defs) ->
         let l, blocks =
           match blocks with
-          | Definition_list (_, l) :: b -> l, b
-          | b -> [], b
+          | Definition_list (_, l) :: b -> (l, b)
+          | b -> ([], b)
         in
-        Definition_list ([], l @ [{ term; defs = List.rev defs}]) :: blocks
-    | Rindented_code l -> (* TODO: trim from the right *)
-        let rec loop = function "" :: l -> loop l | _ as l -> l in
+        Definition_list ([], l @ [ { term; defs = List.rev defs } ]) :: blocks
+    | Rindented_code l ->
+        (* TODO: trim from the right *)
+        let rec loop = function
+          | "" :: l -> loop l
+          | _ as l -> l
+        in
         Code_block ([], "", concat (loop l)) :: blocks
-    | Rhtml (_, l) ->
-       Html_block ([], concat l) :: blocks
-    | Rempty ->
-        blocks
+    | Rhtml (_, l) -> Html_block ([], concat l) :: blocks
+    | Rempty -> blocks
 
-  and finish link_defs state =
-    List.rev (close link_defs state)
+  and finish link_defs state = List.rev (close link_defs state)
 
-  let empty =
-    {blocks = []; next = Rempty}
+  let empty = { blocks = []; next = Rempty }
 
-  let classify_line s =
-    Parser.parse s
+  let classify_line s = Parser.parse s
 
-  let rec process link_defs {blocks; next} s =
+  let rec process link_defs { blocks; next } s =
     let process = process link_defs in
     let close = close link_defs in
     let finish = finish link_defs in
-    match next, classify_line s with
-    | Rempty, Parser.Lempty ->
-        {blocks; next = Rempty}
-    | Rempty, Lblockquote s ->
-        {blocks; next = Rblockquote (process empty s)}
+    match (next, classify_line s) with
+    | Rempty, Parser.Lempty -> { blocks; next = Rempty }
+    | Rempty, Lblockquote s -> { blocks; next = Rblockquote (process empty s) }
     | Rempty, Lthematic_break ->
-        {blocks = Thematic_break [] :: blocks; next = Rempty}
+        { blocks = Thematic_break [] :: blocks; next = Rempty }
     | Rempty, Lsetext_heading (2, n) when n >= 3 ->
-        {blocks = Thematic_break [] :: blocks; next = Rempty}
+        { blocks = Thematic_break [] :: blocks; next = Rempty }
     | Rempty, Latx_heading (level, text, attr) ->
-        {blocks = Heading (attr, level, text) :: blocks; next = Rempty}
+        { blocks = Heading (attr, level, text) :: blocks; next = Rempty }
     | Rempty, Lfenced_code (ind, num, q, info, a) ->
-        {blocks; next = Rfenced_code (ind, num, q, info, [], a)}
-    | Rempty, Lhtml (_, kind) ->
-        process {blocks; next = Rhtml (kind, [])} s
+        { blocks; next = Rfenced_code (ind, num, q, info, [], a) }
+    | Rempty, Lhtml (_, kind) -> process { blocks; next = Rhtml (kind, []) } s
     | Rempty, Lindented_code s ->
-        {blocks; next = Rindented_code [Sub.to_string s]}
+        { blocks; next = Rindented_code [ Sub.to_string s ] }
     | Rempty, Llist_item (kind, indent, s) ->
-        {blocks; next = Rlist (kind, Tight, false, indent, [], process empty s)}
+        { blocks
+        ; next = Rlist (kind, Tight, false, indent, [], process empty s)
+        }
     | Rempty, (Lsetext_heading _ | Lparagraph | Ldef_list _) ->
-        {blocks; next = Rparagraph [Sub.to_string s]}
-    | Rparagraph [h], Ldef_list def ->
-        {blocks; next = Rdef_list (h, [def])}
+        { blocks; next = Rparagraph [ Sub.to_string s ] }
+    | Rparagraph [ h ], Ldef_list def ->
+        { blocks; next = Rdef_list (h, [ def ]) }
     | Rdef_list (term, defs), Ldef_list def ->
-        {blocks; next = Rdef_list (term, def::defs)}
+        { blocks; next = Rdef_list (term, def :: defs) }
     | Rparagraph _, Llist_item ((Ordered (1, _) | Bullet _), _, s1)
       when not (Parser.is_empty (Parser.P.of_string (Sub.to_string s1))) ->
-        process {blocks = close {blocks; next}; next = Rempty} s
-    | Rparagraph _, (Lempty | Lblockquote _ | Lthematic_break
-                    | Latx_heading _ | Lfenced_code _ | Lhtml (true, _)) ->
-        process {blocks = close {blocks; next}; next = Rempty} s
+        process { blocks = close { blocks; next }; next = Rempty } s
+    | ( Rparagraph _
+      , ( Lempty | Lblockquote _ | Lthematic_break | Latx_heading _
+        | Lfenced_code _
+        | Lhtml (true, _) ) ) ->
+        process { blocks = close { blocks; next }; next = Rempty } s
     | Rparagraph (_ :: _ as lines), Lsetext_heading (level, _) ->
         let text = String.trim (String.concat "\n" (List.rev lines)) in
-        {blocks = Heading ([], level, text) :: blocks; next = Rempty}
+        { blocks = Heading ([], level, text) :: blocks; next = Rempty }
     | Rparagraph lines, _ ->
-        {blocks; next = Rparagraph (Sub.to_string s :: lines)}
-    | Rfenced_code (_, num, q, _, _, _), Lfenced_code (_, num', q1, ("", _), _) when num' >= num && q = q1 ->
-        {blocks = close {blocks; next}; next = Rempty}
+        { blocks; next = Rparagraph (Sub.to_string s :: lines) }
+    | Rfenced_code (_, num, q, _, _, _), Lfenced_code (_, num', q1, ("", _), _)
+      when num' >= num && q = q1 ->
+        { blocks = close { blocks; next }; next = Rempty }
     | Rfenced_code (ind, num, q, info, lines, a), _ ->
         let s =
           let ind = min (Parser.indent s) ind in
@@ -127,42 +144,55 @@ module Pre = struct
           else
             s
         in
-        {blocks; next = Rfenced_code (ind, num, q, info, Sub.to_string s :: lines, a)}
-    | Rdef_list (term, d::defs), Lparagraph ->
-        {blocks; next = Rdef_list (term, (d ^ "\n" ^ (Sub.to_string s))::defs)}
+        { blocks
+        ; next = Rfenced_code (ind, num, q, info, Sub.to_string s :: lines, a)
+        }
+    | Rdef_list (term, d :: defs), Lparagraph ->
+        { blocks
+        ; next = Rdef_list (term, (d ^ "\n" ^ Sub.to_string s) :: defs)
+        }
     | Rdef_list _, _ ->
-        process {blocks = close {blocks; next}; next = Rempty} s
+        process { blocks = close { blocks; next }; next = Rempty } s
     | Rindented_code lines, Lindented_code s ->
-        {blocks; next = Rindented_code (Sub.to_string s :: lines)}
+        { blocks; next = Rindented_code (Sub.to_string s :: lines) }
     | Rindented_code lines, Lempty ->
         let n = min (Parser.indent s) 4 in
         let s = Sub.offset n s in
-        {blocks; next = Rindented_code (Sub.to_string s :: lines)}
+        { blocks; next = Rindented_code (Sub.to_string s :: lines) }
     | Rindented_code _, _ ->
-        process {blocks = close {blocks; next}; next = Rempty} s
-    | Rhtml (Hcontains l as k, lines), _ when List.exists (fun t -> Sub.contains t s) l ->
-        {blocks = close {blocks; next = Rhtml (k, Sub.to_string s :: lines)}; next = Rempty}
+        process { blocks = close { blocks; next }; next = Rempty } s
+    | Rhtml ((Hcontains l as k), lines), _
+      when List.exists (fun t -> Sub.contains t s) l ->
+        { blocks = close { blocks; next = Rhtml (k, Sub.to_string s :: lines) }
+        ; next = Rempty
+        }
     | Rhtml (Hblank, _), Lempty ->
-        {blocks = close {blocks; next}; next = Rempty}
+        { blocks = close { blocks; next }; next = Rempty }
     | Rhtml (k, lines), _ ->
-        {blocks; next = Rhtml (k, Sub.to_string s :: lines)}
+        { blocks; next = Rhtml (k, Sub.to_string s :: lines) }
     | Rblockquote state, Lblockquote s ->
-        {blocks; next = Rblockquote (process state s)}
+        { blocks; next = Rblockquote (process state s) }
     | Rlist (kind, style, _, ind, items, state), Lempty ->
-        {blocks; next = Rlist (kind, style, true, ind, items, process state s)}
-    | Rlist (_, _, true, ind, _, {blocks = []; next = Rempty}), _ when Parser.indent s >= ind ->
-        process {blocks = close {blocks; next}; next = Rempty} s
-    | Rlist (kind, style, prev_empty, ind, items, state), _ when Parser.indent s >= ind ->
+        { blocks
+        ; next = Rlist (kind, style, true, ind, items, process state s)
+        }
+    | Rlist (_, _, true, ind, _, { blocks = []; next = Rempty }), _
+      when Parser.indent s >= ind ->
+        process { blocks = close { blocks; next }; next = Rempty } s
+    | Rlist (kind, style, prev_empty, ind, items, state), _
+      when Parser.indent s >= ind ->
         let s = Sub.offset ind s in
         let state = process state s in
         let style =
           let rec new_block = function
-            | Rblockquote {blocks = []; next}
-            | Rlist (_, _, _, _, _, {blocks = []; next}) -> new_block next
-            | Rparagraph [_]
+            | Rblockquote { blocks = []; next }
+            | Rlist (_, _, _, _, _, { blocks = []; next }) ->
+                new_block next
+            | Rparagraph [ _ ]
             | Rfenced_code (_, _, _, _, [], _)
-            | Rindented_code [_]
-            | Rhtml (_, [_]) -> true
+            | Rindented_code [ _ ]
+            | Rhtml (_, [ _ ]) ->
+                true
             | _ -> false
           in
           if prev_empty && new_block state.next then
@@ -170,57 +200,58 @@ module Pre = struct
           else
             style
         in
-        {blocks; next = Rlist (kind, style, false, ind, items, state)}
-    | Rlist (kind, style, prev_empty, _, items, state), Llist_item (kind', ind, s)
+        { blocks; next = Rlist (kind, style, false, ind, items, state) }
+    | ( Rlist (kind, style, prev_empty, _, items, state)
+      , Llist_item (kind', ind, s) )
       when same_block_list_kind kind kind' ->
-        let style = if prev_empty then Loose else style in
-        {blocks; next = Rlist (kind, style, false, ind, finish state :: items, process empty s)}
-    | (Rlist _ | Rblockquote _), _ ->
-        let rec loop = function
-          | Rlist (kind, style, prev_empty, ind, items, {blocks; next}) ->
-              begin match loop next with
-              | Some next ->
-                  Some (Rlist (kind, style, prev_empty, ind, items, {blocks; next}))
-              | None ->
-                  None
-              end
-          | Rblockquote {blocks; next} ->
-              begin match loop next with
-              | Some next ->
-                  Some (Rblockquote {blocks; next})
-              | None ->
-                  None
-              end
-          | Rparagraph (_ :: _ as lines) ->
-              begin match classify_line s with
-              | Parser.Lparagraph | Lindented_code _
-              | Lsetext_heading (1, _) | Lhtml (false, _) ->
-                  Some (Rparagraph (Sub.to_string s :: lines))
-              | _ ->
-                  None
-              end
-          | _ ->
-              None
+        let style =
+          if prev_empty then
+            Loose
+          else
+            style
         in
-        begin match loop next with
-        | Some next ->
-            {blocks; next}
-        | None ->
-            process {blocks = close {blocks; next}; next = Rempty} s
-        end
+        { blocks
+        ; next =
+            Rlist
+              (kind, style, false, ind, finish state :: items, process empty s)
+        }
+    | (Rlist _ | Rblockquote _), _ -> (
+        let rec loop = function
+          | Rlist (kind, style, prev_empty, ind, items, { blocks; next }) -> (
+              match loop next with
+              | Some next ->
+                  Some
+                    (Rlist
+                       (kind, style, prev_empty, ind, items, { blocks; next }))
+              | None -> None)
+          | Rblockquote { blocks; next } -> (
+              match loop next with
+              | Some next -> Some (Rblockquote { blocks; next })
+              | None -> None)
+          | Rparagraph (_ :: _ as lines) -> (
+              match classify_line s with
+              | Parser.Lparagraph
+              | Lindented_code _
+              | Lsetext_heading (1, _)
+              | Lhtml (false, _) ->
+                  Some (Rparagraph (Sub.to_string s :: lines))
+              | _ -> None)
+          | _ -> None
+        in
+        match loop next with
+        | Some next -> { blocks; next }
+        | None -> process { blocks = close { blocks; next }; next = Rempty } s)
 
-  let process link_defs state s =
-    process link_defs state (Sub.of_string s)
+  let process link_defs state s = process link_defs state (Sub.of_string s)
 
   let of_channel ic =
     let link_defs = ref [] in
     let rec loop state =
       match input_line ic with
-      | s ->
-          loop (process link_defs state s)
+      | s -> loop (process link_defs state s)
       | exception End_of_file ->
           let blocks = finish link_defs state in
-          blocks, List.rev !link_defs
+          (blocks, List.rev !link_defs)
     in
     loop empty
 
@@ -228,11 +259,10 @@ module Pre = struct
     let buf = Buffer.create 128 in
     let rec loop cr_read off =
       if off >= String.length s then
-        Buffer.contents buf, None
-      else begin
+        (Buffer.contents buf, None)
+      else
         match s.[off] with
-        | '\n' ->
-            Buffer.contents buf, Some (succ off)
+        | '\n' -> (Buffer.contents buf, Some (succ off))
         | '\r' ->
             if cr_read then Buffer.add_char buf '\r';
             loop true (succ off)
@@ -240,7 +270,6 @@ module Pre = struct
             if cr_read then Buffer.add_char buf '\r';
             Buffer.add_char buf c;
             loop false (succ off)
-      end
     in
     loop false off
 
@@ -249,7 +278,7 @@ module Pre = struct
     let rec loop state = function
       | None ->
           let blocks = finish link_defs state in
-          blocks, List.rev !link_defs
+          (blocks, List.rev !link_defs)
       | Some off ->
           let s, off = read_line s off in
           loop (process link_defs state s) off

--- a/src/block.mli
+++ b/src/block.mli
@@ -1,7 +1,8 @@
 open Ast
 
 module Pre : sig
+  val of_channel :
+    in_channel -> attributes Raw.block list * attributes link_def list
 
-  val of_channel: in_channel -> attributes Raw.block list * attributes link_def list
-  val of_string: string -> attributes Raw.block list * attributes link_def list
+  val of_string : string -> attributes Raw.block list * attributes link_def list
 end

--- a/src/compat.ml
+++ b/src/compat.ml
@@ -1,6 +1,7 @@
 module Uchar = struct
   include Uchar
-  let rep: Uchar.t = of_int(0xFFFD)
+
+  let rep : Uchar.t = of_int 0xFFFD
 end
 
 module List = struct
@@ -9,32 +10,37 @@ module List = struct
   let rec find_map f = function
     | [] -> None
     | x :: xs ->
-        match f x with
-        | None -> find_map f xs
-        | y -> y
+    match f x with
+    | None -> find_map f xs
+    | y -> y
 
   let rec find_opt p = function
-  | [] -> None
-  | x :: l -> if p x then Some x else find_opt p l
+    | [] -> None
+    | x :: l ->
+        if p x then
+          Some x
+        else
+          find_opt p l
 end
 
 module Buffer = struct
   include Buffer
-  let add_utf_8_uchar b u = match Uchar.to_int u with
-  | u when u < 0 -> assert false
-  | u when u <= 0x007F ->
-      Buffer.add_char b (Char.unsafe_chr u)
-  | u when u <= 0x07FF ->
-      Buffer.add_char b (Char.unsafe_chr (0xC0 lor (u lsr 6)));
-      Buffer.add_char b (Char.unsafe_chr (0x80 lor (u land 0x3F)))
-  | u when u <= 0xFFFF ->
-      Buffer.add_char b (Char.unsafe_chr (0xE0 lor (u lsr 12)));
-      Buffer.add_char b (Char.unsafe_chr (0x80 lor ((u lsr 6) land 0x3F)));
-      Buffer.add_char b (Char.unsafe_chr (0x80 lor (u land 0x3F)))
-  | u when u <= 0x10FFFF ->
-      Buffer.add_char b (Char.unsafe_chr (0xF0 lor (u lsr 18)));
-      Buffer.add_char b (Char.unsafe_chr (0x80 lor ((u lsr 12) land 0x3F)));
-      Buffer.add_char b (Char.unsafe_chr (0x80 lor ((u lsr 6) land 0x3F)));
-      Buffer.add_char b (Char.unsafe_chr (0x80 lor (u land 0x3F)))
-  | _ -> assert false
+
+  let add_utf_8_uchar b u =
+    match Uchar.to_int u with
+    | u when u < 0 -> assert false
+    | u when u <= 0x007F -> Buffer.add_char b (Char.unsafe_chr u)
+    | u when u <= 0x07FF ->
+        Buffer.add_char b (Char.unsafe_chr (0xC0 lor (u lsr 6)));
+        Buffer.add_char b (Char.unsafe_chr (0x80 lor (u land 0x3F)))
+    | u when u <= 0xFFFF ->
+        Buffer.add_char b (Char.unsafe_chr (0xE0 lor (u lsr 12)));
+        Buffer.add_char b (Char.unsafe_chr (0x80 lor ((u lsr 6) land 0x3F)));
+        Buffer.add_char b (Char.unsafe_chr (0x80 lor (u land 0x3F)))
+    | u when u <= 0x10FFFF ->
+        Buffer.add_char b (Char.unsafe_chr (0xF0 lor (u lsr 18)));
+        Buffer.add_char b (Char.unsafe_chr (0x80 lor ((u lsr 12) land 0x3F)));
+        Buffer.add_char b (Char.unsafe_chr (0x80 lor ((u lsr 6) land 0x3F)));
+        Buffer.add_char b (Char.unsafe_chr (0x80 lor (u land 0x3F)))
+    | _ -> assert false
 end

--- a/src/dune
+++ b/src/dune
@@ -3,8 +3,9 @@
  (public_name omd)
  (flags :standard -w -30))
 
-
 (rule
  (with-stdout-to
   entities.ml
-  (chdir ../tools (run ./gen_entities.exe %{dep:../tools/entities.json}))))
+  (chdir
+   ../tools
+   (run ./gen_entities.exe %{dep:../tools/entities.json}))))

--- a/src/html.ml
+++ b/src/html.ml
@@ -11,20 +11,20 @@ type t =
   | Null
   | Concat of t * t
 
-let elt etype name attrs childs =
-  Element (etype, name, attrs, childs)
+let elt etype name attrs childs = Element (etype, name, attrs, childs)
 
 let text s = Text s
 
 let raw s = Raw s
 
 let concat t1 t2 =
-  match t1, t2 with
-  | Null, t | t, Null -> t
+  match (t1, t2) with
+  | Null, t
+  | t, Null ->
+      t
   | _ -> Concat (t1, t2)
 
-let concat_map f l =
-  List.fold_left (fun accu x -> concat accu (f x)) Null l
+let concat_map f l = List.fold_left (fun accu x -> concat accu (f x)) Null l
 
 (* only convert when "necessary" *)
 let htmlentities s =
@@ -33,17 +33,13 @@ let htmlentities s =
     if i >= String.length s then
       Buffer.contents b
     else begin
-      begin match s.[i] with
-      | '"' ->
-          Buffer.add_string b "&quot;"
-      | '&' ->
-          Buffer.add_string b "&amp;"
-      | '<' ->
-          Buffer.add_string b "&lt;"
-      | '>' ->
-          Buffer.add_string b "&gt;"
-      | c ->
-          Buffer.add_char b c
+      begin
+        match s.[i] with
+        | '"' -> Buffer.add_string b "&quot;"
+        | '&' -> Buffer.add_string b "&amp;"
+        | '<' -> Buffer.add_string b "&lt;"
+        | '>' -> Buffer.add_string b "&gt;"
+        | c -> Buffer.add_char b c
       end;
       loop (succ i)
     end
@@ -56,42 +52,56 @@ let add_attrs_to_buffer buf attrs =
 
 let rec add_to_buffer buf = function
   | Element (eltype, name, attrs, None) ->
-      Printf.bprintf buf "<%s%a />"
-        name add_attrs_to_buffer attrs;
+      Printf.bprintf buf "<%s%a />" name add_attrs_to_buffer attrs;
       if eltype = Block then Buffer.add_char buf '\n'
   | Element (eltype, name, attrs, Some c) ->
-      Printf.bprintf buf "<%s%a>%a</%s>"
-        name add_attrs_to_buffer attrs add_to_buffer c name;
+      Printf.bprintf
+        buf
+        "<%s%a>%a</%s>"
+        name
+        add_attrs_to_buffer
+        attrs
+        add_to_buffer
+        c
+        name;
       if eltype = Block then Buffer.add_char buf '\n'
-  | Text s ->
-      Buffer.add_string buf (htmlentities s)
-  | Raw s ->
-      Buffer.add_string buf s
-  | Null ->
-      ()
+  | Text s -> Buffer.add_string buf (htmlentities s)
+  | Raw s -> Buffer.add_string buf s
+  | Null -> ()
   | Concat (t1, t2) ->
       add_to_buffer buf t1;
       add_to_buffer buf t2
 
 let escape_uri s =
   let b = Buffer.create (String.length s) in
-  String.iter (function
-      | '!' | '*' | '\'' | '(' | ')' | ';' | ':'
-      | '@' | '=' | '+' | '$' | ',' | '/' | '?' | '%'
-      | '#' | 'A'..'Z' | 'a'..'z' | '0'..'9' | '-' | '_' | '.' | '~' | '&' as c ->
+  String.iter
+    (function
+      | ( '!' | '*' | '\'' | '(' | ')' | ';' | ':' | '@' | '=' | '+' | '$' | ','
+        | '/' | '?' | '%' | '#'
+        | 'A' .. 'Z'
+        | 'a' .. 'z'
+        | '0' .. '9'
+        | '-' | '_' | '.' | '~' | '&' ) as c ->
           Buffer.add_char b c
-      | _ as c ->
-          Printf.bprintf b "%%%2X" (Char.code c)
-    ) s;
+      | _ as c -> Printf.bprintf b "%%%2X" (Char.code c))
+    s;
   Buffer.contents b
 
 let to_plain_text t =
   let buf = Buffer.create 1024 in
   let rec go : _ inline -> unit = function
     | Concat (_, l) -> List.iter go l
-    | Text (_, t) | Code (_, t) -> Buffer.add_string buf t
-    | Emph (_, i) | Strong (_, i) | Link (_, { label = i; _ }) | Image (_, { label = i; _ }) -> go i
-    | Hard_break _ | Soft_break _ -> Buffer.add_char buf ' '
+    | Text (_, t)
+    | Code (_, t) ->
+        Buffer.add_string buf t
+    | Emph (_, i)
+    | Strong (_, i)
+    | Link (_, { label = i; _ })
+    | Image (_, { label = i; _ }) ->
+        go i
+    | Hard_break _
+    | Soft_break _ ->
+        Buffer.add_char buf ' '
     | Html _ -> ()
   in
   go t;
@@ -115,69 +125,65 @@ and img label destination title attrs =
     | Some title -> ("title", title) :: attrs
   in
   let attrs =
-    ("src", escape_uri destination) ::
-    ("alt", to_plain_text label) :: attrs
+    ("src", escape_uri destination) :: ("alt", to_plain_text label) :: attrs
   in
   elt Inline "img" attrs None
 
 and inline = function
-  | Ast.Concat (_, l) ->
-      concat_map inline l
-  | Text (_, t) ->
-      text t
-  | Emph (attr, il) ->
-      elt Inline "em" attr (Some (inline il))
-  | Strong (attr, il) ->
-      elt Inline "strong" attr (Some (inline il))
-  | Code (attr, s) ->
-      elt Inline "code" attr (Some (text s))
-  | Hard_break attr ->
-      concat (elt Inline "br" attr None) nl
-  | Soft_break _ ->
-      nl
-  | Html (_, body) ->
-      raw body
-  | Link (attr, {label; destination; title}) ->
+  | Ast.Concat (_, l) -> concat_map inline l
+  | Text (_, t) -> text t
+  | Emph (attr, il) -> elt Inline "em" attr (Some (inline il))
+  | Strong (attr, il) -> elt Inline "strong" attr (Some (inline il))
+  | Code (attr, s) -> elt Inline "code" attr (Some (text s))
+  | Hard_break attr -> concat (elt Inline "br" attr None) nl
+  | Soft_break _ -> nl
+  | Html (_, body) -> raw body
+  | Link (attr, { label; destination; title }) ->
       url label destination title attr
-  | Image (attr, {label; destination; title}) ->
+  | Image (attr, { label; destination; title }) ->
       img label destination title attr
 
 let rec block = function
   | Blockquote (attr, q) ->
-      elt Block "blockquote" attr
-        (Some (concat nl (concat_map block q)))
-  | Paragraph (attr, md) ->
-      elt Block "p" attr (Some (inline md))
+      elt Block "blockquote" attr (Some (concat nl (concat_map block q)))
+  | Paragraph (attr, md) -> elt Block "p" attr (Some (inline md))
   | List (attr, ty, sp, bl) ->
-      let name = match ty with Ordered _ -> "ol" | Bullet _ -> "ul" in
+      let name =
+        match ty with
+        | Ordered _ -> "ol"
+        | Bullet _ -> "ul"
+      in
       let attr =
         match ty with
-        | Ordered (n, _) when n <> 1 ->
-            ("start", string_of_int n) :: attr
-        | _ ->
-            attr
+        | Ordered (n, _) when n <> 1 -> ("start", string_of_int n) :: attr
+        | _ -> attr
       in
       let li t =
         let block' t =
-          match t, sp with
+          match (t, sp) with
           | Paragraph (_, t), Tight -> concat (inline t) nl
           | _ -> block t
         in
-        let nl = if sp = Tight then Null else nl in
-        elt Block "li" [] (Some (concat nl (concat_map block' t))) in
+        let nl =
+          if sp = Tight then
+            Null
+          else
+            nl
+        in
+        elt Block "li" [] (Some (concat nl (concat_map block' t)))
+      in
       elt Block name attr (Some (concat nl (concat_map li bl)))
   | Code_block (attr, label, code) ->
       let code_attr =
-        if String.trim label = "" then []
-        else ["class", "language-" ^ label]
+        if String.trim label = "" then
+          []
+        else
+          [ ("class", "language-" ^ label) ]
       in
       let c = text code in
-      elt Block "pre" attr
-        (Some (elt Inline "code" code_attr (Some c)))
-  | Thematic_break attr ->
-      elt Block "hr" attr None
-  | Html_block (_, body) ->
-      raw body
+      elt Block "pre" attr (Some (elt Inline "code" code_attr (Some c)))
+  | Thematic_break attr -> elt Block "hr" attr None
+  | Html_block (_, body) -> raw body
   | Heading (attr, level, text) ->
       let name =
         match level with
@@ -191,15 +197,14 @@ let rec block = function
       in
       elt Block name attr (Some (inline text))
   | Definition_list (attr, l) ->
-      let f {term; defs} =
+      let f { term; defs } =
         concat
           (elt Block "dt" [] (Some (inline term)))
           (concat_map (fun s -> elt Block "dd" [] (Some (inline s))) defs)
       in
       elt Block "dl" attr (Some (concat_map f l))
 
-let of_doc doc =
-  concat_map block doc
+let of_doc doc = concat_map block doc
 
 let to_string t =
   let buf = Buffer.create 1024 in

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -1,30 +1,26 @@
 module Pre = Block.Pre
-
 include Ast
 
 type doc = attributes block list
 
-let parse_inline defs s =
-  Parser.inline defs (Parser.P.of_string s)
+let parse_inline defs s = Parser.inline defs (Parser.P.of_string s)
 
 let parse_inlines (md, defs) =
   let defs =
-    let f (def : attributes link_def) = {def with label = Parser.normalize def.label} in
+    let f (def : attributes link_def) =
+      { def with label = Parser.normalize def.label }
+    in
     List.map f defs
   in
   List.map (Mapper.map (parse_inline defs)) md
 
-let of_channel ic =
-  parse_inlines (Pre.of_channel ic)
+let of_channel ic = parse_inlines (Pre.of_channel ic)
 
-let of_string s =
-  parse_inlines (Pre.of_string s)
+let of_string s = parse_inlines (Pre.of_string s)
 
-let to_html doc =
-  Html.to_string (Html.of_doc doc)
+let to_html doc = Html.to_string (Html.of_doc doc)
 
-let to_sexp ast =
-  Format.asprintf "@[%a@]@." Sexp.print (Sexp.create ast)
+let to_sexp ast = Format.asprintf "@[%a@]@." Sexp.print (Sexp.create ast)
 
 let headers = Toc.headers
 

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -1,7 +1,6 @@
 (** A markdown parser in OCaml. *)
 
-type attributes =
-  (string * string) list
+type attributes = (string * string) list
 
 type list_type =
   | Ordered of int * char
@@ -12,10 +11,9 @@ type list_spacing =
   | Tight
 
 type 'attr link =
-  {
-    label: 'attr inline;
-    destination: string;
-    title: string option;
+  { label : 'attr inline
+  ; destination : string
+  ; title : string option
   }
 
 and 'attr inline =
@@ -30,11 +28,9 @@ and 'attr inline =
   | Image of 'attr * 'attr link
   | Html of 'attr * string
 
-
 type 'attr def_elt =
-  {
-    term: 'attr inline;
-    defs: 'attr inline list;
+  { term : 'attr inline
+  ; defs : 'attr inline list
   }
 
 type 'attr block =
@@ -50,14 +46,15 @@ type 'attr block =
 type doc = attributes block list
 (** A markdown document *)
 
-val of_channel: in_channel -> doc
+val of_channel : in_channel -> doc
 
-val of_string: string -> doc
+val of_string : string -> doc
 
-val to_html: doc -> string
+val to_html : doc -> string
 
-val to_sexp: doc -> string
+val to_sexp : doc -> string
 
-val headers : ?remove_links:bool -> 'attr block list -> ('attr * int * 'attr inline) list
+val headers :
+  ?remove_links:bool -> 'attr block list -> ('attr * int * 'attr inline) list
 
-val toc : ?start: int list -> ?depth:int -> doc -> doc
+val toc : ?start:int list -> ?depth:int -> doc -> doc

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -4,70 +4,73 @@ open Compat
 module Sub : sig
   type t
 
-  val of_string: string -> t
-  val to_string: t -> string
-  val offset: int -> t -> t
-  val lexbuf: t -> Lexing.lexbuf
-  val contains: string -> t -> bool
+  val of_string : string -> t
 
-  val print: Format.formatter -> t -> unit
+  val to_string : t -> string
 
-  val head: ?rev:unit -> t -> char option
-  val tail: ?rev:unit -> t -> t
+  val offset : int -> t -> t
 
-  val heads: int -> t -> char list
-  val tails: int -> t -> t
+  val lexbuf : t -> Lexing.lexbuf
 
-  val for_all: (char -> bool) -> t -> bool
-  val exists: (char -> bool) -> t -> bool
-  val is_empty: t -> bool
-  val length: t -> int
+  val contains : string -> t -> bool
 
-  val sub: len:int -> t -> t
+  val print : Format.formatter -> t -> unit
+
+  val head : ?rev:unit -> t -> char option
+
+  val tail : ?rev:unit -> t -> t
+
+  val heads : int -> t -> char list
+
+  val tails : int -> t -> t
+
+  val for_all : (char -> bool) -> t -> bool
+
+  val exists : (char -> bool) -> t -> bool
+
+  val is_empty : t -> bool
+
+  val length : t -> int
+
+  val sub : len:int -> t -> t
 end = struct
   type t =
-    {
-      base: string;
-      off: int;
-      len: int;
+    { base : string
+    ; off : int
+    ; len : int
     }
 
-  let of_string base =
-    {base; off = 0; len = String.length base}
+  let of_string base = { base; off = 0; len = String.length base }
 
-  let to_string {base; off; len} =
-    String.sub base off len
+  let to_string { base; off; len } = String.sub base off len
 
-  let print ppf s =
-    Format.fprintf ppf "%S" (to_string s)
+  let print ppf s = Format.fprintf ppf "%S" (to_string s)
 
-  let length {len; _} =
-    len
+  let length { len; _ } = len
 
-  let offset n {base; off; len} =
+  let offset n { base; off; len } =
     if n < 0 then invalid_arg "offset";
     let rec loop n base off len =
       if n = 0 || len = 0 then
-        {base; off; len}
-      else begin
+        { base; off; len }
+      else
         match base.[off] with
         | '\t' ->
-            let ts = (off + 4) / 4 * 4 - off in
+            let ts = ((off + 4) / 4 * 4) - off in
             let b = Buffer.create len in
             Buffer.add_substring b base 0 off;
-            for _ = 1 to ts do Buffer.add_char b ' ' done;
+            for _ = 1 to ts do
+              Buffer.add_char b ' '
+            done;
             Buffer.add_substring b base (off + 1) (len - 1);
             loop n (Buffer.contents b) off (len + ts - 1)
-        | _ ->
-            loop (n - 1) base (off + 1) (len - 1)
-      end
+        | _ -> loop (n - 1) base (off + 1) (len - 1)
     in
     loop n base off len
 
-  let lexbuf s =
-    Lexing.from_string (to_string s)
+  let lexbuf s = Lexing.from_string (to_string s)
 
-  let contains s1 {base; off; len} =
+  let contains s1 { base; off; len } =
     let rec loop off =
       if off + String.length s1 > len then
         false
@@ -77,28 +80,24 @@ end = struct
     loop off
 
   let head ?rev s =
-    match rev, s with
-    | _, {len = 0; _} ->
-        None
-    | None, {base; off; _} ->
-        Some base.[off]
-    | Some (), {base; off; len} ->
-        Some base.[off + len - 1]
+    match (rev, s) with
+    | _, { len = 0; _ } -> None
+    | None, { base; off; _ } -> Some base.[off]
+    | Some (), { base; off; len } -> Some base.[off + len - 1]
 
   let tail ?rev s =
-    match rev, s with
-    | _, {len = 0; _} ->
-        s
-    | None, {base; off; len} ->
-        {base; off = succ off; len = pred len}
-    | Some (), {base; off; len} ->
-        {base; off; len = pred len}
+    match (rev, s) with
+    | _, { len = 0; _ } -> s
+    | None, { base; off; len } -> { base; off = succ off; len = pred len }
+    | Some (), { base; off; len } -> { base; off; len = pred len }
 
   let heads n s =
     if n < 0 then invalid_arg "heads";
     let rec loop n s =
-      if n = 0 || length s = 0 then []
-      else match head s with
+      if n = 0 || length s = 0 then
+        []
+      else
+        match head s with
         | Some c -> c :: loop (pred n) (tail s)
         | None -> []
     in
@@ -107,13 +106,14 @@ end = struct
   let tails n s =
     if n < 0 then invalid_arg "tails";
     let rec loop n s =
-      if n = 0 then s
-      else loop (pred n) (tail s)
+      if n = 0 then
+        s
+      else
+        loop (pred n) (tail s)
     in
     loop n s
 
-  let is_empty s =
-    length s = 0
+  let is_empty s = length s = 0
 
   let exists f s =
     let rec loop s i =
@@ -126,51 +126,66 @@ end = struct
     in
     loop s 0
 
-  let for_all f s =
-    not (exists (fun c -> not (f c)) s)
+  let for_all f s = not (exists (fun c -> not (f c)) s)
 
   let sub ~len s =
     if len > s.len then invalid_arg "sub";
-    {s with len}
+    { s with len }
 end
 
 exception Fail
 
 module P : sig
   type state
+
   type 'a t = state -> 'a
 
-  val of_string: string -> state
-  val peek: char option t
-  val peek_exn: char t
-  val pos: state -> int
-  val range: state -> int -> int -> string
-  val set_pos: state -> int -> unit
-  val junk: unit t
-  val char: char -> unit t
-  val next: char t
-  val (|||): 'a t -> 'a t -> 'a t
-  val ws: unit t
-  val sp: unit t
-  val ws1: unit t
-  val (>>>): unit t -> 'a t -> 'a t
-  val (<<<): 'a t -> unit t -> 'a t
-  val protect: 'a t -> 'a t
-  val peek_before: char -> state -> char
-  val peek_after: char -> state -> char
-  val pair: 'a t -> 'b t -> ('a * 'b) t
+  val of_string : string -> state
+
+  val peek : char option t
+
+  val peek_exn : char t
+
+  val pos : state -> int
+
+  val range : state -> int -> int -> string
+
+  val set_pos : state -> int -> unit
+
+  val junk : unit t
+
+  val char : char -> unit t
+
+  val next : char t
+
+  val ( ||| ) : 'a t -> 'a t -> 'a t
+
+  val ws : unit t
+
+  val sp : unit t
+
+  val ws1 : unit t
+
+  val ( >>> ) : unit t -> 'a t -> 'a t
+
+  val ( <<< ) : 'a t -> unit t -> 'a t
+
+  val protect : 'a t -> 'a t
+
+  val peek_before : char -> state -> char
+
+  val peek_after : char -> state -> char
+
+  val pair : 'a t -> 'b t -> ('a * 'b) t
 end = struct
   type state =
-    {
-      str: string;
-      mutable pos: int;
+    { str : string
+    ; mutable pos : int
     }
 
-  let of_string str =
-    {str; pos = 0}
+  let of_string str = { str; pos = 0 }
 
-  type 'a t =
-    state -> 'a
+  type 'a t = state -> 'a
 
   let char c st =
     if st.pos >= String.length st.str then raise Fail;
@@ -181,7 +196,9 @@ end = struct
     if st.pos >= String.length st.str then
       raise Fail
     else
-      let c = st.str.[st.pos] in (st.pos <- st.pos + 1; c)
+      let c = st.str.[st.pos] in
+      st.pos <- st.pos + 1;
+      c
 
   let peek_exn st =
     if st.pos >= String.length st.str then
@@ -196,64 +213,83 @@ end = struct
       Some st.str.[st.pos]
 
   let peek_before c st =
-    if st.pos = 0 then c
-    else st.str.[st.pos - 1]
+    if st.pos = 0 then
+      c
+    else
+      st.str.[st.pos - 1]
 
   let peek_after c st =
-    if st.pos + 1 >= String.length st.str then c
-    else st.str.[st.pos + 1]
+    if st.pos + 1 >= String.length st.str then
+      c
+    else
+      st.str.[st.pos + 1]
 
-  let pos st =
-    st.pos
+  let pos st = st.pos
 
-  let range st pos n =
-    String.sub st.str pos n
+  let range st pos n = String.sub st.str pos n
 
-  let set_pos st pos =
-    st.pos <- pos
+  let set_pos st pos = st.pos <- pos
 
-  let junk st =
-    if st.pos < String.length st.str then st.pos <- st.pos + 1
+  let junk st = if st.pos < String.length st.str then st.pos <- st.pos + 1
 
   let protect p st =
     let off = pos st in
-    try p st with e -> set_pos st off; raise e
+    try p st with
+    | e ->
+        set_pos st off;
+        raise e
 
-  let (|||) p1 p2 st =
-    try protect p1 st with Fail -> p2 st
+  let ( ||| ) p1 p2 st =
+    try protect p1 st with
+    | Fail -> p2 st
 
   let ws st =
     let rec loop () =
       match peek_exn st with
-      | ' ' | '\t' | '\010'..'\013' -> junk st; loop ()
+      | ' '
+      | '\t'
+      | '\010' .. '\013' ->
+          junk st;
+          loop ()
       | _ -> ()
     in
-    try loop () with Fail -> ()
+    try loop () with
+    | Fail -> ()
 
   let sp st =
     let rec loop () =
       match peek_exn st with
-      | ' ' | '\t' -> junk st; loop ()
+      | ' '
+      | '\t' ->
+          junk st;
+          loop ()
       | _ -> ()
     in
-    try loop () with Fail -> ()
+    try loop () with
+    | Fail -> ()
 
   let ws1 st =
     match peek_exn st with
-    | ' ' | '\t' | '\010'..'\013' -> junk st; ws st
+    | ' '
+    | '\t'
+    | '\010' .. '\013' ->
+        junk st;
+        ws st
     | _ -> raise Fail
 
-  let (>>>) p q st =
-    p st; q st
+  let ( >>> ) p q st =
+    p st;
+    q st
 
-  let (<<<) p q st =
+  let ( <<< ) p q st =
     let x = p st in
-    q st; x
+    q st;
+    x
 
   let pair p q st =
     let x = p st in
     let y = q st in
-    x, y
+    (x, y)
 end
 
 type html_kind =
@@ -279,135 +315,175 @@ type t =
 
 let sp3 s =
   match Sub.head s with
-  | Some ' ' ->
+  | Some ' ' -> (
       let s = Sub.tail s in
-      begin match Sub.head s with
-      | Some ' ' ->
+      match Sub.head s with
+      | Some ' ' -> (
           let s = Sub.tail s in
-          begin match Sub.head s with
-          | Some ' ' -> 3, Sub.tail s
-          | Some _ | None -> 2, s
-          end
-      | Some _ | None -> 1, s
-      end
-  | Some _ | None -> 0, s
+          match Sub.head s with
+          | Some ' ' -> (3, Sub.tail s)
+          | Some _
+          | None ->
+              (2, s))
+      | Some _
+      | None ->
+          (1, s))
+  | Some _
+  | None ->
+      (0, s)
 
-let (|||) p1 p2 s =
-  try p1 s with Fail -> p2 s
+let ( ||| ) p1 p2 s =
+  try p1 s with
+  | Fail -> p2 s
 
 let rec ws ?rev s =
   match Sub.head ?rev s with
-  | Some (' ' | '\t' | '\010'..'\013') -> ws ?rev (Sub.tail ?rev s)
-  | None | Some _ -> s
+  | Some (' ' | '\t' | '\010' .. '\013') -> ws ?rev (Sub.tail ?rev s)
+  | None
+  | Some _ ->
+      s
 
-let is_empty s =
-  Sub.is_empty (ws s)
+let is_empty s = Sub.is_empty (ws s)
 
 let thematic_break s =
   match Sub.head s with
-  | Some ('*' | '_' | '-' as c) ->
+  | Some (('*' | '_' | '-') as c) ->
       let rec loop n s =
         match Sub.head s with
-        | Some c1 when c = c1 ->
-            loop (succ n) (Sub.tail s)
-        | Some (' ' | '\t' | '\010'..'\013') ->
-            loop n (Sub.tail s)
-        | Some _ ->
-            raise Fail
+        | Some c1 when c = c1 -> loop (succ n) (Sub.tail s)
+        | Some (' ' | '\t' | '\010' .. '\013') -> loop n (Sub.tail s)
+        | Some _ -> raise Fail
         | None ->
             if n < 3 then raise Fail;
             Lthematic_break
       in
       loop 1 (Sub.tail s)
-  | Some _ | None ->
+  | Some _
+  | None ->
       raise Fail
 
 let setext_heading s =
   match Sub.head s with
-  | Some ('-' | '=' as c) ->
+  | Some (('-' | '=') as c) ->
       let rec loop n s =
         match Sub.head s with
-        | Some c1 when c = c1 ->
-            loop (succ n) (Sub.tail s)
-        | Some _ | None ->
+        | Some c1 when c = c1 -> loop (succ n) (Sub.tail s)
+        | Some _
+        | None ->
             if not (Sub.is_empty (ws s)) then raise Fail;
-            if c = '-' && n = 1 then raise Fail; (* can be interpreted as an empty list item *)
-            Lsetext_heading ((if c = '-' then 2 else 1), n)
+            if c = '-' && n = 1 then raise Fail;
+            (* can be interpreted as an empty list item *)
+            Lsetext_heading
+              ( (if c = '-' then
+                  2
+                else
+                  1)
+              , n )
       in
       loop 1 (Sub.tail s)
-  | Some _ | None ->
+  | Some _
+  | None ->
       raise Fail
 
 let is_punct = function
-  | '!' | '"' | '#' | '$' | '%' | '&' | '\'' | '(' | ')'
-  | '*' | '+' | ',' | '-' | '.' | '/' | ':' | ';' | '<'
-  | '=' | '>' | '?' | '@' | '[' | '\\' | ']' | '^' | '_'
-  | '`' | '{' | '|' | '}' | '~' -> true
+  | '!'
+  | '"'
+  | '#'
+  | '$'
+  | '%'
+  | '&'
+  | '\''
+  | '('
+  | ')'
+  | '*'
+  | '+'
+  | ','
+  | '-'
+  | '.'
+  | '/'
+  | ':'
+  | ';'
+  | '<'
+  | '='
+  | '>'
+  | '?'
+  | '@'
+  | '['
+  | '\\'
+  | ']'
+  | '^'
+  | '_'
+  | '`'
+  | '{'
+  | '|'
+  | '}'
+  | '~' ->
+      true
   | _ -> false
 
 let parse_attributes = function
   | None -> []
-  | Some s ->
+  | Some s -> (
       let attributes = String.split_on_char ' ' s in
       let f (id, classes, acc) s =
-        if s = "" then (id, classes, acc)
-        else begin
+        if s = "" then
+          (id, classes, acc)
+        else
           match s.[0] with
-          | '#' ->
-              (Some (String.sub s 1 (String.length s - 1)), classes, acc)
-          | '.' ->
-              (id, String.sub s 1 (String.length s - 1) :: classes, acc)
-          | _ ->
+          | '#' -> (Some (String.sub s 1 (String.length s - 1)), classes, acc)
+          | '.' -> (id, String.sub s 1 (String.length s - 1) :: classes, acc)
+          | _ -> (
               let attr = String.split_on_char '=' s in
               match attr with
               | [] -> (id, classes, acc)
-              | h::t -> (id, classes, (h, String.concat "=" t) :: acc)
-        end
+              | h :: t -> (id, classes, (h, String.concat "=" t) :: acc))
       in
       let id, classes, acc = List.fold_left f (None, [], []) attributes in
       let acc = List.rev acc in
       let acc =
-        if classes <> [] then ("class", String.concat " " (List.rev classes)) :: acc
-        else acc in
+        if classes <> [] then
+          ("class", String.concat " " (List.rev classes)) :: acc
+        else
+          acc
+      in
       match id with
       | Some id -> ("id", id) :: acc
-      | None -> acc
+      | None -> acc)
 
 let attribute_string s =
   let buf = Buffer.create 64 in
   let rec loop s =
     match Sub.head s with
-    | None ->
-        Sub.of_string (Buffer.contents buf), None
-    | Some ('\\' as c) ->
+    | None -> (Sub.of_string (Buffer.contents buf), None)
+    | Some ('\\' as c) -> (
         let s = Sub.tail s in
-        begin match Sub.head s with
+        match Sub.head s with
         | Some c when is_punct c ->
             Buffer.add_char buf c;
             loop (Sub.tail s)
-        | Some _ | None ->
+        | Some _
+        | None ->
             Buffer.add_char buf c;
-            loop s
-        end
+            loop s)
     | Some '{' ->
         let buf' = Buffer.create 64 in
         let rec loop' s =
           match Sub.head s with
-          | Some '}' ->
+          | Some '}' -> (
               let s = Sub.tail s in
-              begin match Sub.head s with
+              match Sub.head s with
               | Some _ ->
                   Buffer.add_char buf '{';
                   Buffer.add_buffer buf buf';
                   Buffer.add_char buf '}';
                   loop s
               | None ->
-                  Sub.of_string (Buffer.contents buf), Some (Buffer.contents buf')
-              end
+                  ( Sub.of_string (Buffer.contents buf)
+                  , Some (Buffer.contents buf') ))
           | None ->
               Buffer.add_char buf '{';
               Buffer.add_buffer buf buf';
-              Sub.of_string (Buffer.contents buf), None
+              (Sub.of_string (Buffer.contents buf), None)
           | Some '{' ->
               Buffer.add_char buf '{';
               Buffer.add_buffer buf buf';
@@ -423,37 +499,31 @@ let attribute_string s =
         loop (Sub.tail s)
   in
   let s', a = loop (ws s) in
-  s', parse_attributes a
+  (s', parse_attributes a)
 
 let atx_heading s =
   let rec loop n s =
     if n > 6 then raise Fail;
     match Sub.head s with
-    | Some '#' ->
-        loop (succ n) (Sub.tail s)
-    | Some (' ' | '\t' | '\010'..'\013') ->
+    | Some '#' -> loop (succ n) (Sub.tail s)
+    | Some (' ' | '\t' | '\010' .. '\013') ->
         let s, a =
           match Sub.head ~rev:() s with
-          | Some '}' ->
-              attribute_string s
-          | _ ->
-              s, []
+          | Some '}' -> attribute_string s
+          | _ -> (s, [])
         in
         let s = ws ~rev:() (ws s) in
         let rec loop t =
           match Sub.head ~rev:() t with
-          | Some '#' ->
-              loop (Sub.tail ~rev:() t)
-          | Some (' ' | '\t' | '\010'..'\013') | None ->
+          | Some '#' -> loop (Sub.tail ~rev:() t)
+          | Some (' ' | '\t' | '\010' .. '\013')
+          | None ->
               ws ~rev:() t
-          | Some _ ->
-              s
+          | Some _ -> s
         in
         Latx_heading (n, Sub.to_string (ws (loop s)), a)
-    | Some _ ->
-        raise Fail
-    | None ->
-        Latx_heading (n, Sub.to_string s, [])
+    | Some _ -> raise Fail
+    | None -> Latx_heading (n, Sub.to_string s, [])
   in
   loop 0 s
 
@@ -463,17 +533,29 @@ let entity s =
       let rec loop m n s =
         if m > 8 then raise Fail;
         match Sub.head s with
-        | Some ('a'..'f' as c) ->
-            loop (succ m) (n * 16 + Char.code c - Char.code 'a' + 10) (Sub.tail s)
-        | Some ('A'..'F' as c) ->
-            loop (succ m) (n * 16 + Char.code c - Char.code 'A' + 10) (Sub.tail s)
-        | Some ('0'..'9' as c) ->
-            loop (succ m) (n * 16 + Char.code c - Char.code '0') (Sub.tail s)
+        | Some ('a' .. 'f' as c) ->
+            loop
+              (succ m)
+              ((n * 16) + Char.code c - Char.code 'a' + 10)
+              (Sub.tail s)
+        | Some ('A' .. 'F' as c) ->
+            loop
+              (succ m)
+              ((n * 16) + Char.code c - Char.code 'A' + 10)
+              (Sub.tail s)
+        | Some ('0' .. '9' as c) ->
+            loop (succ m) ((n * 16) + Char.code c - Char.code '0') (Sub.tail s)
         | Some ';' ->
             if m = 0 then raise Fail;
-            let u = if n = 0 || not (Uchar.is_valid n) then Uchar.rep else Uchar.of_int n in
-            [u], Sub.tail s
-        | Some _ | None ->
+            let u =
+              if n = 0 || not (Uchar.is_valid n) then
+                Uchar.rep
+              else
+                Uchar.of_int n
+            in
+            ([ u ], Sub.tail s)
+        | Some _
+        | None ->
             raise Fail
       in
       loop 0 0 (Sub.tails 2 s)
@@ -481,71 +563,81 @@ let entity s =
       let rec loop m n s =
         if m > 8 then raise Fail;
         match Sub.head s with
-        | Some ('0'..'9' as c) ->
-            loop (succ m) (n * 10 + Char.code c - Char.code '0') (Sub.tail s)
+        | Some ('0' .. '9' as c) ->
+            loop (succ m) ((n * 10) + Char.code c - Char.code '0') (Sub.tail s)
         | Some ';' ->
             if m = 0 then raise Fail;
-            let u = if n = 0 || not (Uchar.is_valid n) then Uchar.rep else Uchar.of_int n in
-            [u], Sub.tail s
-        | Some _ | None ->
+            let u =
+              if n = 0 || not (Uchar.is_valid n) then
+                Uchar.rep
+              else
+                Uchar.of_int n
+            in
+            ([ u ], Sub.tail s)
+        | Some _
+        | None ->
             raise Fail
       in
       loop 0 0 (Sub.tail s)
-  | ('a'..'z' | 'A'..'Z') :: _ ->
+  | ('a' .. 'z' | 'A' .. 'Z') :: _ ->
       let rec loop len t =
         match Sub.head t with
-        | Some ('a'..'z' | 'A'..'Z' | '0'..'9') ->
+        | Some ('a' .. 'z' | 'A' .. 'Z' | '0' .. '9') ->
             loop (succ len) (Sub.tail t)
-        | Some ';' ->
+        | Some ';' -> (
             let name = Sub.to_string (Sub.sub ~len s) in
-            begin match Entities.f name with
+            match Entities.f name with
             | [] -> raise Fail
-            | cps -> cps, Sub.tail t
-            end
-        | Some _ | None ->
+            | cps -> (cps, Sub.tail t))
+        | Some _
+        | None ->
             raise Fail
       in
       loop 1 (Sub.tail s)
-  | _ ->
-      raise Fail
+  | _ -> raise Fail
 
 let info_string c s =
   let buf = Buffer.create 17 in
   let s, a =
     match Sub.head ~rev:() s with
-    | Some '}' ->
-        attribute_string s
-    | _ ->
-        s, []
+    | Some '}' -> attribute_string s
+    | _ -> (s, [])
   in
   let s = ws ~rev:() (ws s) in
   let rec loop s =
     match Sub.head s with
-    | Some (' ' | '\t' | '\010'..'\013') | None ->
-        if c = '`' && Sub.exists (function '`' -> true | _ -> false) s then raise Fail;
-        (Buffer.contents buf, Sub.to_string (ws s)), a
-    | Some '`' when c = '`' ->
-        raise Fail
-    | Some ('\\' as c) ->
+    | Some (' ' | '\t' | '\010' .. '\013')
+    | None ->
+        if
+          c = '`'
+          && Sub.exists
+               (function
+                 | '`' -> true
+                 | _ -> false)
+               s
+        then
+          raise Fail;
+        ((Buffer.contents buf, Sub.to_string (ws s)), a)
+    | Some '`' when c = '`' -> raise Fail
+    | Some ('\\' as c) -> (
         let s = Sub.tail s in
-        begin match Sub.head s with
+        match Sub.head s with
         | Some c when is_punct c ->
             Buffer.add_char buf c;
             loop (Sub.tail s)
-        | Some _ | None ->
+        | Some _
+        | None ->
             Buffer.add_char buf c;
-            loop s
-        end
-    | Some ('&' as c) ->
+            loop s)
+    | Some ('&' as c) -> (
         let s = Sub.tail s in
-        begin match entity s with
-        | (ul, s) ->
+        match entity s with
+        | ul, s ->
             List.iter (Buffer.add_utf_8_uchar buf) ul;
             loop s
         | exception Fail ->
             Buffer.add_char buf c;
-            loop s
-        end
+            loop s)
     | Some c ->
         Buffer.add_char buf c;
         loop (Sub.tail s)
@@ -554,96 +646,166 @@ let info_string c s =
 
 let fenced_code ind s =
   match Sub.head s with
-  | Some ('`' | '~' as c) ->
+  | Some (('`' | '~') as c) ->
       let rec loop n s =
         match Sub.head s with
-        | Some c1 when c = c1 ->
-            loop (succ n) (Sub.tail s)
-        | Some _ | None ->
+        | Some c1 when c = c1 -> loop (succ n) (Sub.tail s)
+        | Some _
+        | None ->
             if n < 3 then raise Fail;
             let s, a = info_string c s in
-            let c = if c = '`' then Backtick else Tilde in
+            let c =
+              if c = '`' then
+                Backtick
+              else
+                Tilde
+            in
             Lfenced_code (ind, n, c, s, a)
       in
       loop 1 (Sub.tail s)
-  | Some _ | None ->
+  | Some _
+  | None ->
       raise Fail
 
 let indent s =
   let rec loop n s =
     match Sub.head s with
-    | Some ' ' ->
-        loop (n + 1) (Sub.tail s)
-    | Some '\t' ->
-        loop (n + 4) (Sub.tail s)
-    | Some _ | None ->
+    | Some ' ' -> loop (n + 1) (Sub.tail s)
+    | Some '\t' -> loop (n + 4) (Sub.tail s)
+    | Some _
+    | None ->
         n
   in
   loop 0 s
 
 let unordered_list_item ind s =
   match Sub.head s with
-  | Some ('+' | '-' | '*' as c) ->
+  | Some (('+' | '-' | '*') as c) ->
       let s = Sub.tail s in
       if is_empty s then
         Llist_item (Bullet c, 2 + ind, s)
       else
         let n = indent s in
         if n = 0 then raise Fail;
-        let n = if n <= 4 then n else 1 in
+        let n =
+          if n <= 4 then
+            n
+          else
+            1
+        in
         Llist_item (Bullet c, n + 1 + ind, Sub.offset n s)
-  | Some _ | None ->
+  | Some _
+  | None ->
       raise Fail
 
 let ordered_list_item ind s =
   let rec loop n m s =
     match Sub.head s with
-    | Some ('0'..'9' as c) ->
+    | Some ('0' .. '9' as c) ->
         if n >= 9 then raise Fail;
-        loop (succ n) (m * 10 + Char.code c - Char.code '0') (Sub.tail s)
-    | Some ('.' | ')' as c) ->
+        loop (succ n) ((m * 10) + Char.code c - Char.code '0') (Sub.tail s)
+    | Some (('.' | ')') as c) ->
         let s = Sub.tail s in
         if is_empty s then
           Llist_item (Ordered (m, c), n + 1 + ind, s)
-        else begin
+        else
           let ind' = indent s in
           if ind' = 0 then raise Fail;
-          let ind' = if ind' <= 4 then ind' else 1 in
+          let ind' =
+            if ind' <= 4 then
+              ind'
+            else
+              1
+          in
           Llist_item (Ordered (m, c), n + ind + ind' + 1, Sub.offset ind' s)
-        end
-    | Some _ | None ->
+    | Some _
+    | None ->
         raise Fail
   in
   loop 0 0 s
 
 let tag_name s0 =
   match Sub.head s0 with
-  | Some ('a'..'z' | 'A'..'Z') ->
+  | Some ('a' .. 'z' | 'A' .. 'Z') ->
       let rec loop len s =
         match Sub.head s with
-        | Some ('a'..'z' | 'A'..'Z' | '0'..'9' | '-') ->
+        | Some ('a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-') ->
             loop (succ len) (Sub.tail s)
-        | Some _ | None ->
-            Sub.to_string (Sub.sub s0 ~len), s
+        | Some _
+        | None ->
+            (Sub.to_string (Sub.sub s0 ~len), s)
       in
       loop 1 (Sub.tail s0)
-  | Some _ | None ->
+  | Some _
+  | None ->
       raise Fail
 
 let known_tags =
-  [ "address"; "aside"; "base"; "basefont"; "blockquote";
-    "body"; "caption"; "center"; "col"; "colgroup"; "dd";
-    "details"; "dialog"; "dir"; "div"; "dl"; "dt";
-    "fieldset"; "figcaption"; "figure"; "footer"; "form";
-    "frame"; "frameset"; "h1"; "h2"; "h3"; "h4"; "h5";
-    "h6"; "head"; "header"; "hr"; "html"; "iframe"; "legend";
-    "li"; "link"; "main"; "menu"; "menuitem"; "meta"; "nav";
-    "noframes"; "ol"; "optgroup"; "option"; "p"; "param";
-    "section"; "source"; "summary"; "table"; "tbody";
-    "td"; "tfoot"; "th"; "thead"; "title"; "tr"; "track"; "ul" ]
+  [ "address"
+  ; "aside"
+  ; "base"
+  ; "basefont"
+  ; "blockquote"
+  ; "body"
+  ; "caption"
+  ; "center"
+  ; "col"
+  ; "colgroup"
+  ; "dd"
+  ; "details"
+  ; "dialog"
+  ; "dir"
+  ; "div"
+  ; "dl"
+  ; "dt"
+  ; "fieldset"
+  ; "figcaption"
+  ; "figure"
+  ; "footer"
+  ; "form"
+  ; "frame"
+  ; "frameset"
+  ; "h1"
+  ; "h2"
+  ; "h3"
+  ; "h4"
+  ; "h5"
+  ; "h6"
+  ; "head"
+  ; "header"
+  ; "hr"
+  ; "html"
+  ; "iframe"
+  ; "legend"
+  ; "li"
+  ; "link"
+  ; "main"
+  ; "menu"
+  ; "menuitem"
+  ; "meta"
+  ; "nav"
+  ; "noframes"
+  ; "ol"
+  ; "optgroup"
+  ; "option"
+  ; "p"
+  ; "param"
+  ; "section"
+  ; "source"
+  ; "summary"
+  ; "table"
+  ; "tbody"
+  ; "td"
+  ; "tfoot"
+  ; "th"
+  ; "thead"
+  ; "title"
+  ; "tr"
+  ; "track"
+  ; "ul"
+  ]
 
-let special_tags =
-  [ "script"; "pre"; "style" ]
+let special_tags = [ "script"; "pre"; "style" ]
 
 let known_tag s =
   let s = String.lowercase_ascii s in
@@ -659,71 +821,73 @@ let closing_tag s =
   | Some '>' ->
       if not (is_empty (Sub.tail s)) then raise Fail;
       Lhtml (false, Hblank)
-  | Some _ | None ->
+  | Some _
+  | None ->
       raise Fail
 
 let special_tag tag s =
   if not (special_tag tag) then raise Fail;
   match Sub.head s with
-  | Some (' ' | '\t' | '\010'..'\013' | '>') | None ->
-      Lhtml (true, Hcontains ["</script>"; "</pre>"; "</style>"])
-  | Some _ ->
-      raise Fail
+  | Some (' ' | '\t' | '\010' .. '\013' | '>')
+  | None ->
+      Lhtml (true, Hcontains [ "</script>"; "</pre>"; "</style>" ])
+  | Some _ -> raise Fail
 
 let known_tag tag s =
   if not (known_tag tag) then raise Fail;
   match Sub.heads 2 s with
-  | (' ' | '\t' | '\010'..'\013') :: _
-  | [] | '>' :: _ | '/' :: '>' :: _ -> Lhtml (true, Hblank)
+  | (' ' | '\t' | '\010' .. '\013') :: _
+  | []
+  | '>' :: _
+  | '/' :: '>' :: _ ->
+      Lhtml (true, Hblank)
   | _ -> raise Fail
 
 let ws1 s =
   match Sub.head s with
-  | Some (' ' | '\t' | '\010'..'\013') ->
-      ws s
-  | Some _ | None ->
+  | Some (' ' | '\t' | '\010' .. '\013') -> ws s
+  | Some _
+  | None ->
       raise Fail
 
 let attribute_name s =
   match Sub.head s with
-  | Some ('a'..'z' | 'A'..'Z' | '_' | ':') ->
+  | Some ('a' .. 'z' | 'A' .. 'Z' | '_' | ':') ->
       let rec loop s =
         match Sub.head s with
-        | Some ('a'..'z' | 'A'..'Z' | '_' | '.' | ':' | '0'..'9') ->
+        | Some ('a' .. 'z' | 'A' .. 'Z' | '_' | '.' | ':' | '0' .. '9') ->
             loop (Sub.tail s)
-        | Some _ | None ->
+        | Some _
+        | None ->
             s
       in
       loop s
-  | Some _ | None ->
+  | Some _
+  | None ->
       raise Fail
 
 let attribute_value s =
   match Sub.head s with
-  | Some ('\'' | '"' as c) ->
+  | Some (('\'' | '"') as c) ->
       let rec loop s =
         match Sub.head s with
-        | Some c1 when c = c1 ->
-            Sub.tail s
-        | Some _ ->
-            loop (Sub.tail s)
-        | None ->
-            raise Fail
+        | Some c1 when c = c1 -> Sub.tail s
+        | Some _ -> loop (Sub.tail s)
+        | None -> raise Fail
       in
       loop (Sub.tail s)
   | Some _ ->
       let rec loop first s =
         match Sub.head s with
-        | Some (' ' | '\t' | '\010'..'\013' | '"' | '\'' | '=' | '<' | '>' | '`')
+        | Some
+            (' ' | '\t' | '\010' .. '\013' | '"' | '\'' | '=' | '<' | '>' | '`')
         | None ->
             if first then raise Fail;
             s
-        | Some _ ->
-            loop false (Sub.tail s)
+        | Some _ -> loop false (Sub.tail s)
       in
       loop true s
-  | None ->
-      raise Fail
+  | None -> raise Fail
 
 let attribute s =
   let s = ws1 s in
@@ -733,7 +897,8 @@ let attribute s =
   | Some '=' ->
       let s = ws (Sub.tail s) in
       attribute_value s
-  | Some _ | None ->
+  | Some _
+  | None ->
       s
 
 let attributes s =
@@ -758,22 +923,18 @@ let open_tag s =
 
 let raw_html s =
   match Sub.heads 10 s with
-  | '<' :: '?' :: _ ->
-      Lhtml (true, Hcontains ["?>"])
-  | '<' :: '!' :: '-' :: '-' :: _ ->
-      Lhtml (true, Hcontains ["-->"])
+  | '<' :: '?' :: _ -> Lhtml (true, Hcontains [ "?>" ])
+  | '<' :: '!' :: '-' :: '-' :: _ -> Lhtml (true, Hcontains [ "-->" ])
   | '<' :: '!' :: '[' :: 'C' :: 'D' :: 'A' :: 'T' :: 'A' :: '[' :: _ ->
-      Lhtml (true, Hcontains ["]]>"])
-  | '<' :: '!' :: _ ->
-      Lhtml (true, Hcontains [">"])
+      Lhtml (true, Hcontains [ "]]>" ])
+  | '<' :: '!' :: _ -> Lhtml (true, Hcontains [ ">" ])
   | '<' :: '/' :: _ ->
       let tag, s = tag_name (Sub.tails 2 s) in
       (known_tag tag ||| closing_tag) s
   | '<' :: _ ->
       let tag, s = tag_name (Sub.tails 1 s) in
       (special_tag tag ||| known_tag tag ||| open_tag) s
-  | _ ->
-      raise Fail
+  | _ -> raise Fail
 
 let blank s =
   if not (is_empty s) then raise Fail;
@@ -783,16 +944,15 @@ let tag_string s =
   let buf = Buffer.create 17 in
   let s, a =
     match Sub.head ~rev:() s with
-    | Some '}' ->
-        attribute_string s
-    | _ ->
-        s, []
+    | Some '}' -> attribute_string s
+    | _ -> (s, [])
   in
   let s = ws ~rev:() (ws s) in
   let rec loop s =
     match Sub.head s with
-    | Some (' ' | '\t' | '\010'..'\013') | None ->
-        Buffer.contents buf, a
+    | Some (' ' | '\t' | '\010' .. '\013')
+    | None ->
+        (Buffer.contents buf, a)
     | Some c ->
         Buffer.add_char buf c;
         loop (Sub.tail s)
@@ -801,8 +961,9 @@ let tag_string s =
 
 let def_list s =
   let s = Sub.tail s in
-  match Sub.head (s) with
-  | Some (' ' | '\t' | '\010'..'\013') -> Ldef_list (String.trim (Sub.to_string s))
+  match Sub.head s with
+  | Some (' ' | '\t' | '\010' .. '\013') ->
+      Ldef_list (String.trim (Sub.to_string s))
   | _ -> raise Fail
 
 let indented_code ind s =
@@ -814,35 +975,30 @@ let parse s0 =
   match Sub.head s with
   | Some '>' ->
       let s = Sub.offset 1 s in
-      let s = if indent s > 0 then Sub.offset 1 s else s in
+      let s =
+        if indent s > 0 then
+          Sub.offset 1 s
+        else
+          s
+      in
       Lblockquote s
-  | Some '=' ->
-      setext_heading s
+  | Some '=' -> setext_heading s
   | Some '-' ->
       (setext_heading ||| thematic_break ||| unordered_list_item ind) s
-  | Some ('_') ->
-      thematic_break s
-  | Some '#' ->
-      atx_heading s
-  | Some ('~' | '`') ->
-      fenced_code ind s
-  | Some '<' ->
-      raw_html s
-  | Some '*' ->
-      (thematic_break ||| unordered_list_item ind) s
-  | Some '+' ->
-      unordered_list_item ind s
-  | Some ('0'..'9') ->
-      ordered_list_item ind s
-  | Some ':' ->
-      def_list s
-  | Some _ ->
-      (blank ||| indented_code ind) s
-  | None ->
-      Lempty
+  | Some '_' -> thematic_break s
+  | Some '#' -> atx_heading s
+  | Some ('~' | '`') -> fenced_code ind s
+  | Some '<' -> raw_html s
+  | Some '*' -> (thematic_break ||| unordered_list_item ind) s
+  | Some '+' -> unordered_list_item ind s
+  | Some '0' .. '9' -> ordered_list_item ind s
+  | Some ':' -> def_list s
+  | Some _ -> (blank ||| indented_code ind) s
+  | None -> Lempty
 
 let parse s =
-  try parse s with Fail -> Lparagraph
+  try parse s with
+  | Fail -> Lparagraph
 
 open P
 
@@ -851,13 +1007,19 @@ let is_empty st =
   try
     let rec loop () =
       match next st with
-      | ' ' | '\t' | '\010'..'\013' -> loop ()
-      | _ -> set_pos st off; false
+      | ' '
+      | '\t'
+      | '\010' .. '\013' ->
+          loop ()
+      | _ ->
+          set_pos st off;
+          false
     in
     loop ()
-  with Fail ->
-    set_pos st off;
-    true
+  with
+  | Fail ->
+      set_pos st off;
+      true
 
 let inline_attribute_string s =
   let ppos = pos s in
@@ -871,8 +1033,10 @@ let inline_attribute_string s =
           | Some '}' ->
               junk s;
               Some (Buffer.contents buf)
-          | None | Some '{' ->
-              set_pos s pos; None
+          | None
+          | Some '{' ->
+              set_pos s pos;
+              None
           | Some c ->
               Buffer.add_char buf c;
               junk s;
@@ -880,93 +1044,101 @@ let inline_attribute_string s =
         in
         junk s;
         loop s (pos s)
-    | _ ->
-        None
+    | _ -> None
   in
   let attr = parse_attributes a in
-  if attr = []
-  then
-    set_pos s ppos;
+  if attr = [] then set_pos s ppos;
   attr
 
 let entity buf st =
   let p = pos st in
   if next st <> '&' then raise Fail;
   match peek st with
-  | Some '#' ->
+  | Some '#' -> (
       junk st;
-      begin match peek st with
+      match peek st with
       | Some ('x' | 'X') ->
           junk st;
           let rec aux n m =
-            if n > 8 then Buffer.add_string buf (range st p (pos st - p))
-            else begin
+            if n > 8 then
+              Buffer.add_string buf (range st p (pos st - p))
+            else
               match peek st with
-              | Some ('0'..'9' as c) ->
+              | Some ('0' .. '9' as c) ->
                   junk st;
-                  aux (succ n) (m * 16 + Char.code c - Char.code '0')
-              | Some ('a'..'f' as c) ->
+                  aux (succ n) ((m * 16) + Char.code c - Char.code '0')
+              | Some ('a' .. 'f' as c) ->
                   junk st;
-                  aux (succ n) (m * 16 + Char.code c - Char.code 'a' + 10)
-              | Some ('A'..'F' as c) ->
+                  aux (succ n) ((m * 16) + Char.code c - Char.code 'a' + 10)
+              | Some ('A' .. 'F' as c) ->
                   junk st;
-                  aux (succ n) (m * 16 + Char.code c - Char.code 'A' + 10)
+                  aux (succ n) ((m * 16) + Char.code c - Char.code 'A' + 10)
               | Some ';' ->
                   junk st;
                   if n = 0 then
                     Buffer.add_string buf (range st p (pos st - p))
                   else
-                    let u = if Uchar.is_valid m && m <> 0 then Uchar.of_int m else Uchar.rep in
+                    let u =
+                      if Uchar.is_valid m && m <> 0 then
+                        Uchar.of_int m
+                      else
+                        Uchar.rep
+                    in
                     Buffer.add_utf_8_uchar buf u
-              | Some _ | None ->
+              | Some _
+              | None ->
                   Buffer.add_string buf (range st p (pos st - p))
-            end
           in
           aux 0 0
-      | Some '0'..'9' ->
+      | Some '0' .. '9' ->
           let rec aux n m =
-            if n > 8 then Buffer.add_string buf (range st p (pos st - p))
-            else begin
+            if n > 8 then
+              Buffer.add_string buf (range st p (pos st - p))
+            else
               match peek st with
-              | Some ('0'..'9' as c) ->
+              | Some ('0' .. '9' as c) ->
                   junk st;
-                  aux (succ n) (m * 10 + Char.code c - Char.code '0')
+                  aux (succ n) ((m * 10) + Char.code c - Char.code '0')
               | Some ';' ->
                   junk st;
                   if n = 0 then
                     Buffer.add_string buf (range st p (pos st - p))
-                  else begin
-                    let u = if Uchar.is_valid m && m <> 0 then Uchar.of_int m else Uchar.rep in
+                  else
+                    let u =
+                      if Uchar.is_valid m && m <> 0 then
+                        Uchar.of_int m
+                      else
+                        Uchar.rep
+                    in
                     Buffer.add_utf_8_uchar buf u
-                  end
-              | Some _ | None ->
+              | Some _
+              | None ->
                   Buffer.add_string buf (range st p (pos st - p))
-            end
           in
           aux 0 0
-      | Some _ | None ->
-          Buffer.add_string buf (range st p (pos st - p))
-      end
-  | Some ('0'..'9' | 'a'..'z' | 'A'..'Z') ->
+      | Some _
+      | None ->
+          Buffer.add_string buf (range st p (pos st - p)))
+  | Some ('0' .. '9' | 'a' .. 'z' | 'A' .. 'Z') ->
       let q = pos st in
       let rec aux () =
         match peek st with
-        | Some ('0'..'9' | 'a'..'z' | 'A'..'Z') ->
-            junk st; aux ()
-        | Some ';' ->
+        | Some ('0' .. '9' | 'a' .. 'z' | 'A' .. 'Z') ->
+            junk st;
+            aux ()
+        | Some ';' -> (
             let name = range st q (pos st - q) in
             junk st;
-            begin match Entities.f name with
-            | [] ->
-                Buffer.add_string buf (range st p (pos st - p))
-            | _ :: _ as cps ->
-                List.iter (Buffer.add_utf_8_uchar buf) cps
-            end
-        | Some _ | None ->
+            match Entities.f name with
+            | [] -> Buffer.add_string buf (range st p (pos st - p))
+            | _ :: _ as cps -> List.iter (Buffer.add_utf_8_uchar buf) cps)
+        | Some _
+        | None ->
             Buffer.add_string buf (range st p (pos st - p))
       in
       aux ()
-  | Some _ | None ->
+  | Some _
+  | None ->
       Buffer.add_string buf (range st p (pos st - p))
 
 module Pre = struct
@@ -990,41 +1162,72 @@ module Pre = struct
     | R of attributes inline
 
   let concat = function
-    | [x] -> x
+    | [ x ] -> x
     | l -> Concat ([], l)
 
   let left_flanking = function
-    | Emph (_, Other, _, _) | Emph ((Ws | Punct), Punct, _, _) -> true
+    | Emph (_, Other, _, _)
+    | Emph ((Ws | Punct), Punct, _, _) ->
+        true
     | _ -> false
 
   let right_flanking = function
-    | Emph (Other, _, _, _) | Emph (Punct, (Ws | Punct), _, _) -> true
+    | Emph (Other, _, _, _)
+    | Emph (Punct, (Ws | Punct), _, _) ->
+        true
     | _ -> false
 
   let is_opener = function
     | Emph (pre, _, Underscore, _) as x ->
-        left_flanking x && (not (right_flanking x) || pre = Punct)
-    | Emph (_, _, Star, _) as x ->
-        left_flanking x
-    | _ ->
-        false
+        left_flanking x && ((not (right_flanking x)) || pre = Punct)
+    | Emph (_, _, Star, _) as x -> left_flanking x
+    | _ -> false
 
   let is_closer = function
     | Emph (_, post, Underscore, _) as x ->
-        right_flanking x && (not (left_flanking x) || post = Punct)
-    | Emph (_, _, Star, _) as x ->
-        right_flanking x
-    | _ ->
-        false
+        right_flanking x && ((not (left_flanking x)) || post = Punct)
+    | Emph (_, _, Star, _) as x -> right_flanking x
+    | _ -> false
 
   let classify_delim = function
-    | '!' | '"' | '#' | '$' | '%'
-    | '&' | '\'' | '(' | ')' | '*' | '+'
-    | ',' | '-' | '.' | '/' | ':' | ';'
-    | '<' | '=' | '>' | '?' | '@' | '['
-    | '\\' | ']' | '^' | '_' | '`' | '{'
-    | '|' | '}' | '~' -> Punct
-    | ' ' | '\t' | '\010'..'\013' | '\160' -> Ws
+    | '!'
+    | '"'
+    | '#'
+    | '$'
+    | '%'
+    | '&'
+    | '\''
+    | '('
+    | ')'
+    | '*'
+    | '+'
+    | ','
+    | '-'
+    | '.'
+    | '/'
+    | ':'
+    | ';'
+    | '<'
+    | '='
+    | '>'
+    | '?'
+    | '@'
+    | '['
+    | '\\'
+    | ']'
+    | '^'
+    | '_'
+    | '`'
+    | '{'
+    | '|'
+    | '}'
+    | '~' ->
+        Punct
+    | ' '
+    | '\t'
+    | '\010' .. '\013'
+    | '\160' ->
+        Ws
     | _ -> Other
 
   let to_r = function
@@ -1036,14 +1239,19 @@ module Pre = struct
     | R x -> x
 
   let rec parse_emph = function
-    | Emph (pre, _, q1, n1) as x :: xs when is_opener x ->
+    | (Emph (pre, _, q1, n1) as x) :: xs when is_opener x ->
         let rec loop acc = function
-          | Emph (_, post, q2, n2) as x :: xs when is_closer x && q1 = q2 ->
+          | (Emph (_, post, q2, n2) as x) :: xs when is_closer x && q1 = q2 ->
               let xs =
                 if n1 >= 2 && n2 >= 2 then
-                  if n2 > 2 then Emph (Punct, post, q2, n2-2) :: xs else xs
+                  if n2 > 2 then
+                    Emph (Punct, post, q2, n2 - 2) :: xs
+                  else
+                    xs
+                else if n2 > 1 then
+                  Emph (Punct, post, q2, n2 - 1) :: xs
                 else
-                if n2 > 1 then Emph (Punct, post, q2, n2-1) :: xs else xs
+                  xs
               in
               let r =
                 let il = concat (List.map to_r (parse_emph (List.rev acc))) in
@@ -1054,35 +1262,40 @@ module Pre = struct
               in
               let r =
                 if n1 >= 2 && n2 >= 2 then
-                  if n1 > 2 then Emph (pre, Punct, q1, n1-2) :: r else r
+                  if n1 > 2 then
+                    Emph (pre, Punct, q1, n1 - 2) :: r
+                  else
+                    r
+                else if n1 > 1 then
+                  Emph (pre, Punct, q1, n1 - 1) :: r
                 else
-                if n1 > 1 then Emph (pre, Punct, q1, n1-1) :: r else r
+                  r
               in
               parse_emph r
-          | Emph _ as x :: xs1 as xs when is_opener x ->
+          | (Emph _ as x) :: xs1 as xs when is_opener x ->
               let xs' = parse_emph xs in
-              if xs' = xs then loop (x :: acc) xs1 else loop acc xs'
-          | x :: xs ->
-              loop (x :: acc) xs
-          | [] ->
-              x :: List.rev acc
+              if xs' = xs then
+                loop (x :: acc) xs1
+              else
+                loop acc xs'
+          | x :: xs -> loop (x :: acc) xs
+          | [] -> x :: List.rev acc
         in
         loop [] xs
-    | x :: xs ->
-        x :: parse_emph xs
-    | [] ->
-        []
+    | x :: xs -> x :: parse_emph xs
+    | [] -> []
 
-  let parse_emph xs =
-    concat (List.map to_r (parse_emph xs))
+  let parse_emph xs = concat (List.map to_r (parse_emph xs))
 end
 
 let escape buf st =
   if next st <> '\\' then raise Fail;
   match peek st with
   | Some c when is_punct c ->
-      junk st; Buffer.add_char buf c
-  | Some _ | None ->
+      junk st;
+      Buffer.add_char buf c
+  | Some _
+  | None ->
       Buffer.add_char buf '\\'
 
 let link_label allow_balanced_brackets st =
@@ -1101,22 +1314,29 @@ let link_label allow_balanced_brackets st =
         Buffer.add_char buf c;
         loop (pred n) true
     | '\\' as c ->
-        junk st; Buffer.add_char buf c;
-        begin match peek_exn st with
-        | c when is_punct c ->
-            junk st; Buffer.add_char buf c
-        | _ ->
-            ()
+        junk st;
+        Buffer.add_char buf c;
+        begin
+          match peek_exn st with
+          | c when is_punct c ->
+              junk st;
+              Buffer.add_char buf c
+          | _ -> ()
         end;
         loop n true
-    | '[' when not allow_balanced_brackets ->
-        raise Fail
+    | '[' when not allow_balanced_brackets -> raise Fail
     | '[' as c ->
-        junk st; Buffer.add_char buf c; loop (succ n) true
-    | ' ' | '\t' | '\010'..'\013' as c ->
-        junk st; Buffer.add_char buf c; loop n nonempty
+        junk st;
+        Buffer.add_char buf c;
+        loop (succ n) true
+    | (' ' | '\t' | '\010' .. '\013') as c ->
+        junk st;
+        Buffer.add_char buf c;
+        loop n nonempty
     | _ as c ->
-        junk st; Buffer.add_char buf c; loop n true
+        junk st;
+        Buffer.add_char buf c;
+        loop n true
   in
   loop 0 false
 
@@ -1125,38 +1345,45 @@ let normalize s =
   let rec loop start seen_ws i =
     if i >= String.length s then
       Buffer.contents buf
-    else begin
+    else
       match s.[i] with
-      | ' ' | '\t' | '\010'..'\013' ->
+      | ' '
+      | '\t'
+      | '\010' .. '\013' ->
           loop start true (succ i)
       | _ as c ->
-          if not start && seen_ws then Buffer.add_char buf ' ';
+          if (not start) && seen_ws then Buffer.add_char buf ' ';
           Buffer.add_char buf (Char.lowercase_ascii c);
           loop false false (succ i)
-    end
   in
   loop true false 0
 
 let tag_name st =
   match peek_exn st with
-  | 'a'..'z' | 'A'..'Z' ->
+  | 'a' .. 'z'
+  | 'A' .. 'Z' ->
       junk st;
       let rec loop () =
         match peek st with
-        | Some ('a'..'z' | 'A'..'Z' | '0'..'9' | '-') ->
-            junk st; loop ()
-        | Some _ | None -> ()
+        | Some ('a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-') ->
+            junk st;
+            loop ()
+        | Some _
+        | None ->
+            ()
       in
       loop ()
-  | _ ->
-      raise Fail
+  | _ -> raise Fail
 
 let ws_buf buf st =
   let rec loop () =
     match peek st with
-    | Some (' ' | '\t' | '\010'..'\013' as c) ->
-        Buffer.add_char buf c; junk st; loop ()
-    | Some _ | None ->
+    | Some ((' ' | '\t' | '\010' .. '\013') as c) ->
+        Buffer.add_char buf c;
+        junk st;
+        loop ()
+    | Some _
+    | None ->
         ()
   in
   loop ()
@@ -1182,12 +1409,12 @@ let single_quoted_attribute st =
   if next st <> '\'' then raise Fail;
   let rec loop () =
     match peek_exn st with
-    | '\'' ->
-        junk st
+    | '\'' -> junk st
     (* | '&' -> *)
     (*     entity buf st; loop () *)
     | _ ->
-        junk st; loop ()
+        junk st;
+        loop ()
   in
   loop ()
 
@@ -1195,24 +1422,33 @@ let double_quoted_attribute st =
   if next st <> '"' then raise Fail;
   let rec loop () =
     match peek_exn st with
-    | '"' ->
-        junk st
+    | '"' -> junk st
     (* | '&' -> *)
     (*     entity buf st; loop () *)
     | _ ->
-        junk st; loop ()
+        junk st;
+        loop ()
   in
   loop ()
 
 let unquoted_attribute st =
   let rec loop n =
     match peek_exn st with
-    | ' ' | '\t' | '\010'..'\013' | '"' | '\'' | '=' | '<' | '>' | '`' ->
+    | ' '
+    | '\t'
+    | '\010' .. '\013'
+    | '"'
+    | '\''
+    | '='
+    | '<'
+    | '>'
+    | '`' ->
         if n = 0 then raise Fail
     (* | '&' -> *)
     (*     entity buf st; loop () *)
     | _ ->
-        junk st; loop (succ n)
+        junk st;
+        loop (succ n)
   in
   loop 0
 
@@ -1224,35 +1460,37 @@ let attribute_value st =
 
 let attribute_name st =
   match peek_exn st with
-  | 'a'..'z' | 'A'..'Z' | '_' | ':' ->
+  | 'a' .. 'z'
+  | 'A' .. 'Z'
+  | '_'
+  | ':' ->
       junk st;
       let rec loop () =
         match peek st with
-        | Some ('a'..'z' | 'A'..'Z' | '0'..'9' | '_' | '.' | ':' | '-') ->
-            junk st; loop ()
-        | Some _ | None ->
+        | Some ('a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '.' | ':' | '-') ->
+            junk st;
+            loop ()
+        | Some _
+        | None ->
             ()
       in
       loop ()
-  | _ ->
-      raise Fail
+  | _ -> raise Fail
 
 let option d p st =
   match protect p st with
   | r -> r
   | exception Fail -> d
 
-let some p st =
-  Some (p st)
+let some p st = Some (p st)
 
-let attribute_value_specification =
-  ws >>> char '=' >>> ws >>> attribute_value
+let attribute_value_specification = ws >>> char '=' >>> ws >>> attribute_value
 
 let ws1_buf buf st =
   match peek st with
-  | Some (' ' | '\t' | '\010'..'\013') ->
-      ws_buf buf st
-  | Some _ | None ->
+  | Some (' ' | '\t' | '\010' .. '\013') -> ws_buf buf st
+  | Some _
+  | None ->
       raise Fail
 
 let attribute st =
@@ -1266,9 +1504,10 @@ let open_tag st =
   tag_name st;
   list attribute st;
   ws st;
-  begin match peek_exn st with
-  | '/' -> junk st
-  | _ -> ()
+  begin
+    match peek_exn st with
+    | '/' -> junk st
+    | _ -> ()
   end;
   if next st <> '>' then raise Fail;
   range st start (pos st - start)
@@ -1282,25 +1521,26 @@ let html_comment st =
   Buffer.add_string buf "<!--";
   let rec loop start =
     match peek_exn st with
-    | '-' as c ->
+    | '-' as c -> (
         junk st;
-        begin match peek_exn st with
+        match peek_exn st with
         | '-' ->
             junk st;
             if next st <> '>' then raise Fail;
             Buffer.add_string buf "-->";
             Buffer.contents buf
-        | '>' when start ->
-            raise Fail
+        | '>' when start -> raise Fail
         | _ ->
-            Buffer.add_char buf c; loop false
-        end
-    | '>' when start ->
-        raise Fail
+            Buffer.add_char buf c;
+            loop false)
+    | '>' when start -> raise Fail
     | '&' ->
-        entity buf st; loop false
+        entity buf st;
+        loop false
     | _ as c ->
-        junk st; Buffer.add_char buf c; loop false
+        junk st;
+        Buffer.add_char buf c;
+        loop false
   in
   loop true
 
@@ -1311,18 +1551,23 @@ let processing_instruction st =
   Buffer.add_string buf "<?";
   let rec loop () =
     match peek_exn st with
-    | '?' as c ->
+    | '?' as c -> (
         junk st;
-        begin match peek_exn st with
+        match peek_exn st with
         | '>' ->
-            junk st; Buffer.add_string buf "?>"; Buffer.contents buf
+            junk st;
+            Buffer.add_string buf "?>";
+            Buffer.contents buf
         | _ ->
-            Buffer.add_char buf c; loop ()
-        end
+            Buffer.add_char buf c;
+            loop ())
     | '&' ->
-        entity buf st; loop ()
+        entity buf st;
+        loop ()
     | _ as c ->
-        junk st; Buffer.add_char buf c; loop ()
+        junk st;
+        Buffer.add_char buf c;
+        loop ()
   in
   loop ()
 
@@ -1340,24 +1585,30 @@ let cdata_section st =
   Buffer.add_string buf "<![CDATA[";
   let rec loop () =
     match peek_exn st with
-    | ']' as c ->
+    | ']' as c -> (
         junk st;
-        begin match peek_exn st with
-        | ']' as c1 ->
+        match peek_exn st with
+        | ']' as c1 -> (
             junk st;
-            begin match peek_exn st with
+            match peek_exn st with
             | '>' ->
-                junk st; Buffer.add_string buf "]]>"; Buffer.contents buf
+                junk st;
+                Buffer.add_string buf "]]>";
+                Buffer.contents buf
             | _ ->
-                Buffer.add_char buf c; Buffer.add_char buf c1; loop ()
-            end
+                Buffer.add_char buf c;
+                Buffer.add_char buf c1;
+                loop ())
         | _ ->
-            Buffer.add_char buf c; loop ()
-        end
+            Buffer.add_char buf c;
+            loop ())
     | '&' ->
-        entity buf st; loop ()
+        entity buf st;
+        loop ()
     | _ as c ->
-        junk st; Buffer.add_char buf c; loop ()
+        junk st;
+        Buffer.add_char buf c;
+        loop ()
   in
   loop ()
 
@@ -1367,30 +1618,36 @@ let declaration st =
   if next st <> '!' then raise Fail;
   Buffer.add_string buf "<!";
   match peek_exn st with
-  | 'A'..'Z' ->
+  | 'A' .. 'Z' ->
       let rec loop () =
         match peek_exn st with
-        | 'A'..'Z' as c ->
-            junk st; Buffer.add_char buf c; loop ()
-        | ' ' | '\t' | '\010'..'\013' ->
+        | 'A' .. 'Z' as c ->
+            junk st;
+            Buffer.add_char buf c;
+            loop ()
+        | ' '
+        | '\t'
+        | '\010' .. '\013' ->
             ws1_buf buf st;
             let rec loop () =
               match peek_exn st with
               | '>' as c ->
-                  junk st; Buffer.add_char buf c; Buffer.contents buf
+                  junk st;
+                  Buffer.add_char buf c;
+                  Buffer.contents buf
               | '&' ->
-                  entity buf st; loop ()
+                  entity buf st;
+                  loop ()
               | _ as c ->
-                  junk st; Buffer.add_char buf c; loop ()
+                  junk st;
+                  Buffer.add_char buf c;
+                  loop ()
             in
             loop ()
-        | _ ->
-            raise Fail
+        | _ -> raise Fail
       in
       loop ()
-  | _ ->
-      raise Fail
-
+  | _ -> raise Fail
 
 let link_destination st =
   let buf = Buffer.create 17 in
@@ -1400,36 +1657,51 @@ let link_destination st =
       let rec loop () =
         match peek_exn st with
         | '>' ->
-            junk st; Buffer.contents buf
-        | '\010'..'\013' | '<' ->
+            junk st;
+            Buffer.contents buf
+        | '\010' .. '\013'
+        | '<' ->
             raise Fail
         | '\\' ->
-            escape buf st; loop ()
+            escape buf st;
+            loop ()
         | '&' ->
-            entity buf st; loop ()
+            entity buf st;
+            loop ()
         | _ as c ->
-            junk st; Buffer.add_char buf c; loop ()
+            junk st;
+            Buffer.add_char buf c;
+            loop ()
       in
       loop ()
   | _ ->
       let rec loop n =
         match peek st with
         | Some ('(' as c) ->
-            junk st; Buffer.add_char buf c; loop (succ n)
+            junk st;
+            Buffer.add_char buf c;
+            loop (succ n)
         | Some ')' when n = 0 ->
             if Buffer.length buf = 0 then raise Fail;
             Buffer.contents buf
         | Some (')' as c) ->
-            junk st; Buffer.add_char buf c; loop (pred n)
+            junk st;
+            Buffer.add_char buf c;
+            loop (pred n)
         | Some '\\' ->
-            escape buf st; loop n
+            escape buf st;
+            loop n
         | Some '&' ->
-            entity buf st; loop n
-        | Some (' ' | '\t' | '\x00'..'\x1F' | '\x7F' | '\x80'..'\x9F') | None ->
+            entity buf st;
+            loop n
+        | Some (' ' | '\t' | '\x00' .. '\x1F' | '\x7F' | '\x80' .. '\x9F')
+        | None ->
             if n > 0 || Buffer.length buf = 0 then raise Fail;
             Buffer.contents buf
         | Some c ->
-            junk st; Buffer.add_char buf c; loop n
+            junk st;
+            Buffer.add_char buf c;
+            loop n
       in
       loop 0
 
@@ -1442,18 +1714,23 @@ let eol st =
 let link_title st =
   let buf = Buffer.create 17 in
   match peek_exn st with
-  | '\'' | '"' as c ->
+  | ('\'' | '"') as c ->
       junk st;
       let rec loop () =
         match peek_exn st with
         | '\\' ->
-            escape buf st; loop ()
+            escape buf st;
+            loop ()
         | '&' ->
-            entity buf st; loop ()
+            entity buf st;
+            loop ()
         | _ as c1 when c = c1 ->
-            junk st; Buffer.contents buf
+            junk st;
+            Buffer.contents buf
         | _ as c1 ->
-            junk st; Buffer.add_char buf c1; loop ()
+            junk st;
+            Buffer.add_char buf c1;
+            loop ()
       in
       loop ()
   | '(' ->
@@ -1461,18 +1738,21 @@ let link_title st =
       let rec loop () =
         match peek_exn st with
         | '\\' ->
-            escape buf st; loop ()
+            escape buf st;
+            loop ()
         | '&' ->
-            entity buf st; loop ()
+            entity buf st;
+            loop ()
         | ')' ->
             junk st;
             Buffer.contents buf
         | _ as c ->
-            junk st; Buffer.add_char buf c; loop ()
+            junk st;
+            Buffer.add_char buf c;
+            loop ()
       in
       loop ()
-  | _ ->
-      raise Fail
+  | _ -> raise Fail
 
 let space st =
   match peek_exn st with
@@ -1481,26 +1761,31 @@ let space st =
 
 let many p st =
   try
-    while true do p st done
-  with Fail ->
-    ()
+    while true do
+      p st
+    done
+  with
+  | Fail -> ()
 
 let scheme st =
   match peek_exn st with
-  | 'a'..'z' | 'A'..'Z' ->
+  | 'a' .. 'z'
+  | 'A' .. 'Z' ->
       let rec loop n =
-        if n < 32 then begin
+        if n < 32 then
           match peek st with
-          | Some ('a'..'z' | 'A'..'Z' | '0'..'9' | '+' | '.' | '-') ->
-              junk st; loop (succ n)
-          | Some _ | None ->
+          | Some ('a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '+' | '.' | '-') ->
+              junk st;
+              loop (succ n)
+          | Some _
+          | None ->
               n
-        end else n
+        else
+          n
       in
       let n = loop 0 in
       if n < 2 then raise Fail
-  | _ ->
-      raise Fail
+  | _ -> raise Fail
 
 let absolute_uri st =
   let p = pos st in
@@ -1508,11 +1793,18 @@ let absolute_uri st =
   if next st <> ':' then raise Fail;
   let rec loop () =
     match peek st with
-    | Some (' ' | '\t' | '\010'..'\013' | '\x00'..'\x1F' | '\x7F'..'\x9F' | '<' | '>') | None ->
+    | Some
+        ( ' ' | '\t'
+        | '\010' .. '\013'
+        | '\x00' .. '\x1F'
+        | '\x7F' .. '\x9F'
+        | '<' | '>' )
+    | None ->
         let txt = range st p (pos st - p) in
-        txt, txt
+        (txt, txt)
     | Some _ ->
-        junk st; loop ()
+        junk st;
+        loop ()
   in
   loop ()
 
@@ -1520,36 +1812,59 @@ let email_address st =
   let p = pos st in
   let rec loop n =
     match peek_exn st with
-    | 'a'..'z' | 'A'..'Z' | '0'..'9'
-    | '.' | '!' | '#' | '$' | '%' | '&' | '\'' | '*'
-    | '+' | '/' | '=' | '?' | '^' | '_' | '`' | '{' | '|'
-    | '}' | '~' | '-' ->
-        junk st; loop (succ n)
+    | 'a' .. 'z'
+    | 'A' .. 'Z'
+    | '0' .. '9'
+    | '.'
+    | '!'
+    | '#'
+    | '$'
+    | '%'
+    | '&'
+    | '\''
+    | '*'
+    | '+'
+    | '/'
+    | '='
+    | '?'
+    | '^'
+    | '_'
+    | '`'
+    | '{'
+    | '|'
+    | '}'
+    | '~'
+    | '-' ->
+        junk st;
+        loop (succ n)
     | '@' ->
         junk st;
         let label st =
           let let_dig st =
             match peek_exn st with
-            | 'a'..'z' | 'A'..'Z' | '0'..'9' -> junk st; false
-            | '-' -> junk st; true
+            | 'a' .. 'z'
+            | 'A' .. 'Z'
+            | '0' .. '9' ->
+                junk st;
+                false
+            | '-' ->
+                junk st;
+                true
             | _ -> raise Fail
           in
           if let_dig st then raise Fail;
           let rec loop last =
             match let_dig st with
-            | r ->
-                loop r
-            | exception Fail ->
-                if last then raise Fail
+            | r -> loop r
+            | exception Fail -> if last then raise Fail
           in
           loop false
         in
         label st;
         list (char '.' >>> label) st;
         let txt = range st p (pos st - p) in
-        txt, "mailto:" ^ txt
-    | _ ->
-        raise Fail
+        (txt, "mailto:" ^ txt)
+    | _ -> raise Fail
   in
   loop 0
 
@@ -1559,15 +1874,17 @@ let autolink st =
       junk st;
       let label, destination = (absolute_uri ||| email_address) st in
       if next st <> '>' then raise Fail;
-      {Ast.label = Text ([], label); destination; title = None}
-  | _ ->
-      raise Fail
+      { Ast.label = Text ([], label); destination; title = None }
+  | _ -> raise Fail
 
 let inline_link =
-  char '(' >>> ws >>>
-  option ("", None)
-    (pair link_destination (option None (ws1 >>> some link_title)))
-  <<< ws <<< char ')'
+  char '('
+  >>> ws
+  >>> option
+        ("", None)
+        (pair link_destination (option None (ws1 >>> some link_title)))
+  <<< ws
+  <<< char ')'
 
 let get_buf buf =
   let s = Buffer.contents buf in
@@ -1584,16 +1901,20 @@ let inline_pre buf acc st =
   let pos = pos st in
   let rec gobble_open_backtick n =
     match peek st with
-    | Some '`' -> junk st; gobble_open_backtick (succ n)
+    | Some '`' ->
+        junk st;
+        gobble_open_backtick (succ n)
     | Some _ ->
         let acc = text buf acc in
         let bufcode = Buffer.create 17 in
         let finish () =
           let content = Buffer.contents bufcode in
           let content =
-            if String.length content >= 2 &&
-                content.[0] = ' ' &&
-                content.[String.length content - 1] = ' ' (* FIXME not fully whitespace *)
+            if
+              String.length content >= 2
+              && content.[0] = ' '
+              && content.[String.length content - 1] = ' '
+              (* FIXME not fully whitespace *)
             then
               String.sub content 1 (String.length content - 2)
             else
@@ -1605,12 +1926,19 @@ let inline_pre buf acc st =
         let rec gobble_body start m =
           match peek st with
           | Some '`' ->
-              junk st; gobble_body start (succ m)
+              junk st;
+              gobble_body start (succ m)
           | _ when m = n -> finish ()
-          | Some (' ' | '\t' | '\010'..'\013' as c) ->
+          | Some ((' ' | '\t' | '\010' .. '\013') as c) ->
               if m > 0 then Buffer.add_string bufcode (String.make m '`');
-              Buffer.add_char bufcode (if c = '\010' then ' ' else c);
-              junk st; gobble_body (start && m = 0) 0
+              Buffer.add_char
+                bufcode
+                (if c = '\010' then
+                  ' '
+                else
+                  c);
+              junk st;
+              gobble_body (start && m = 0) 0
           | Some c ->
               junk st;
               (* if seen_ws then Buffer.add_char bufcode ' '; *)
@@ -1624,7 +1952,8 @@ let inline_pre buf acc st =
         in
         gobble_body true 0
     | None ->
-        Buffer.add_string buf (String.make n '`'); acc
+        Buffer.add_string buf (String.make n '`');
+        acc
   in
   gobble_open_backtick 0
 
@@ -1634,16 +1963,22 @@ let rec inline defs st =
   let rec reference_link kind acc st =
     let off0 = pos st in
     match protect (link_label true) st with
-    | lab ->
+    | lab -> (
         let off1 = pos st in
         let lab1 = inline defs (of_string lab) in
         let reflink lab' =
           let s = normalize lab' in
-          match List.find_opt (fun ({label; _} : attributes link_def) -> label = s) defs with
-          | Some {label = _; destination; title; attributes = attr} ->
+          match
+            List.find_opt
+              (fun ({ label; _ } : attributes link_def) -> label = s)
+              defs
+          with
+          | Some { label = _; destination; title; attributes = attr } ->
               let r =
-                let def = {label = lab1; destination; title} in
-                match kind with Pre.Img -> Image (attr, def) | Url -> Link (attr, def)
+                let def = { label = lab1; destination; title } in
+                match kind with
+                | Pre.Img -> Image (attr, def)
+                | Url -> Link (attr, def)
               in
               loop (Pre.R r :: text acc) st
           | None ->
@@ -1654,119 +1989,145 @@ let rec inline defs st =
               set_pos st off1;
               loop acc st
         in
-        begin match peek st with
-        | Some '[' ->
-            if peek_after '\000' st = ']' then
-              (junk st; junk st; reflink lab)
-            else begin
+        match peek st with
+        | Some '[' -> (
+            if peek_after '\000' st = ']' then (
+              junk st;
+              junk st;
+              reflink lab
+            ) else
               match protect (link_label false) st with
               | _ ->
-                  set_pos st off0; junk st; loop (Left_bracket kind :: text acc) st
-              | exception Fail ->
-                  reflink lab
-            end
-        | Some '(' ->
-            begin match protect inline_link st with
+                  set_pos st off0;
+                  junk st;
+                  loop (Left_bracket kind :: text acc) st
+              | exception Fail -> reflink lab)
+        | Some '(' -> (
+            match protect inline_link st with
             | _ ->
-                set_pos st off0; junk st; loop (Left_bracket kind :: text acc) st
-            | exception Fail ->
-                reflink lab
-            end
-        | Some _ | None ->
-            reflink lab
-        end
+                set_pos st off0;
+                junk st;
+                loop (Left_bracket kind :: text acc) st
+            | exception Fail -> reflink lab)
+        | Some _
+        | None ->
+            reflink lab)
     | exception Fail ->
-        junk st; loop (Left_bracket kind :: text acc) st
+        junk st;
+        loop (Left_bracket kind :: text acc) st
   and loop acc st =
     match peek_exn st with
-    | '<' as c ->
-        begin match protect autolink st with
+    | '<' as c -> (
+        match protect autolink st with
         | def ->
             let attr = inline_attribute_string st in
             loop (Pre.R (Link (attr, def)) :: text acc) st
         | exception Fail ->
-            begin match
-              protect (closing_tag ||| open_tag ||| html_comment |||
-                       declaration ||| cdata_section ||| processing_instruction) st
-            with
-            | tag ->
-                loop (Pre.R (Html ([], tag)) :: text acc) st
-            | exception Fail ->
-                junk st; Buffer.add_char buf c; loop acc st
-            end
-        end
+        match
+          protect
+            (closing_tag
+            ||| open_tag
+            ||| html_comment
+            ||| declaration
+            ||| cdata_section
+            ||| processing_instruction)
+            st
+        with
+        | tag -> loop (Pre.R (Html ([], tag)) :: text acc) st
+        | exception Fail ->
+            junk st;
+            Buffer.add_char buf c;
+            loop acc st)
     | '\n' ->
-        junk st; sp st; loop (Pre.R (Soft_break []) :: text acc) st
-    | ' ' as c ->
         junk st;
-        begin match peek st with
-        | Some ' ' ->
-            begin match protect (many space >>> char '\n' >>> many space) st with
-            | () ->
-                loop (Pre.R (Hard_break []) :: text acc) st
+        sp st;
+        loop (Pre.R (Soft_break []) :: text acc) st
+    | ' ' as c -> (
+        junk st;
+        match peek st with
+        | Some ' ' -> (
+            match protect (many space >>> char '\n' >>> many space) st with
+            | () -> loop (Pre.R (Hard_break []) :: text acc) st
             | exception Fail ->
                 junk st;
-                Buffer.add_string buf "  "; loop acc st
-            end
-        | Some '\n' ->
-            loop acc st
-        | Some _ | None ->
-            Buffer.add_char buf c; loop acc st
-        end
+                Buffer.add_string buf "  ";
+                loop acc st)
+        | Some '\n' -> loop acc st
+        | Some _
+        | None ->
+            Buffer.add_char buf c;
+            loop acc st)
     | '`' -> loop (inline_pre buf acc st) st
-    | '\\' as c ->
+    | '\\' as c -> (
         junk st;
-        begin match peek st with
+        match peek st with
         | Some '\n' ->
-            junk st; loop (Pre.R (Hard_break []) :: text acc) st
+            junk st;
+            loop (Pre.R (Hard_break []) :: text acc) st
         | Some c when is_punct c ->
-            junk st; Buffer.add_char buf c; loop acc st
-        | Some _ | None ->
-            Buffer.add_char buf c; loop acc st
-        end
-    | '!' as c ->
+            junk st;
+            Buffer.add_char buf c;
+            loop acc st
+        | Some _
+        | None ->
+            Buffer.add_char buf c;
+            loop acc st)
+    | '!' as c -> (
         junk st;
-        begin match peek st with
-        | Some '[' ->
-            reference_link Img (text acc) st
-        | Some _ | None ->
-            Buffer.add_char buf c; loop acc st
-        end
+        match peek st with
+        | Some '[' -> reference_link Img (text acc) st
+        | Some _
+        | None ->
+            Buffer.add_char buf c;
+            loop acc st)
     | '&' ->
-        entity buf st; loop acc st
+        entity buf st;
+        loop acc st
     | ']' ->
         junk st;
         let acc = text acc in
         let rec aux seen_link xs = function
           | Pre.Left_bracket Url :: _ when seen_link ->
-              Buffer.add_char buf ']'; loop acc st
-          | Left_bracket k :: acc' ->
-              begin match peek st with
-              | Some '(' ->
-                  begin match protect inline_link st with
+              Buffer.add_char buf ']';
+              loop acc st
+          | Left_bracket k :: acc' -> (
+              match peek st with
+              | Some '(' -> (
+                  match protect inline_link st with
                   | destination, title ->
                       let attr = inline_attribute_string st in
                       let r =
                         let label = Pre.parse_emph xs in
-                        let def = {label; destination; title} in
+                        let def = { label; destination; title } in
                         match k with
                         | Img -> Image (attr, def)
                         | Url -> Link (attr, def)
                       in
                       loop (Pre.R r :: acc') st
                   | exception Fail ->
-                      Buffer.add_char buf ']'; loop acc st
-                  end
-              | Some '[' ->
+                      Buffer.add_char buf ']';
+                      loop acc st)
+              | Some '[' -> (
                   let label = Pre.parse_emph xs in
                   let off1 = pos st in
-                  begin match link_label false st with
-                  | lab ->
+                  match link_label false st with
+                  | lab -> (
                       let s = normalize lab in
-                      begin match List.find_opt (fun ({label; _} : attributes link_def) -> label = s) defs with
-                      | Some {label = _; destination; title; attributes = attr} ->
-                          let def = {label; destination; title} in
-                          let r = match k with Img -> Image (attr, def) | Url -> Link (attr, def) in
+                      match
+                        List.find_opt
+                          (fun ({ label; _ } : attributes link_def) ->
+                            label = s)
+                          defs
+                      with
+                      | Some
+                          { label = _; destination; title; attributes = attr }
+                        ->
+                          let def = { label; destination; title } in
+                          let r =
+                            match k with
+                            | Img -> Image (attr, def)
+                            | Url -> Link (attr, def)
+                          in
                           loop (Pre.R r :: acc') st
                       | None ->
                           if k = Img then Buffer.add_char buf '!';
@@ -1774,66 +2135,71 @@ let rec inline defs st =
                           let acc = Pre.R label :: text acc' in
                           Buffer.add_char buf ']';
                           set_pos st off1;
-                          loop acc st
-                      end
+                          loop acc st)
                   | exception Fail ->
                       if k = Img then Buffer.add_char buf '!';
                       Buffer.add_char buf '[';
                       let acc = Pre.R label :: text acc in
                       Buffer.add_char buf ']';
                       set_pos st off1;
-                      loop acc st
-                  end
-              | Some _ | None ->
-                  Buffer.add_char buf ']'; loop acc st
-              end
-          | Pre.R (Link _) as x :: acc' ->
-              aux true (x :: xs) acc'
-          | x :: acc' ->
-              aux seen_link (x :: xs) acc'
+                      loop acc st)
+              | Some _
+              | None ->
+                  Buffer.add_char buf ']';
+                  loop acc st)
+          | (Pre.R (Link _) as x) :: acc' -> aux true (x :: xs) acc'
+          | x :: acc' -> aux seen_link (x :: xs) acc'
           | [] ->
-              Buffer.add_char buf ']'; loop acc st
+              Buffer.add_char buf ']';
+              loop acc st
         in
         aux false [] acc
-    | '[' ->
-        reference_link Url acc st
-    | '*' | '_' as c ->
+    | '[' -> reference_link Url acc st
+    | ('*' | '_') as c ->
         let pre = peek_before ' ' st in
         let f post n st =
           let pre = pre |> Pre.classify_delim in
           let post = post |> Pre.classify_delim in
-          let e = if c = '*' then Pre.Star else Pre.Underscore in
+          let e =
+            if c = '*' then
+              Pre.Star
+            else
+              Pre.Underscore
+          in
           loop (Pre.Emph (pre, post, e, n) :: text acc) st
         in
         let rec aux n =
           match peek st with
-          | Some c1 when c1 = c -> junk st; aux (succ n)
+          | Some c1 when c1 = c ->
+              junk st;
+              aux (succ n)
           | Some c1 -> f c1 n st
           | None -> f ' ' n st
         in
         aux 0
     | _ as c ->
-        junk st; Buffer.add_char buf c; loop acc st
-    | exception Fail ->
-        Pre.parse_emph (List.rev (text acc))
+        junk st;
+        Buffer.add_char buf c;
+        loop acc st
+    | exception Fail -> Pre.parse_emph (List.rev (text acc))
   in
   loop [] st
 
 let sp3 st =
   match peek_exn st with
-  | ' ' ->
+  | ' ' -> (
       junk st;
-      begin match peek_exn st with
-      | ' ' ->
+      match peek_exn st with
+      | ' ' -> (
           junk st;
-          begin match peek_exn st with
-          | ' ' -> junk st; 3
+          match peek_exn st with
+          | ' ' ->
+              junk st;
+              3
           | _ -> 2
-          | exception Fail -> 2
-          end
+          | exception Fail -> 2)
       | _ -> 1
-      | exception Fail -> 1
-      end
+      | exception Fail -> 1)
   | _ -> 0
   | exception Fail -> 0
 
@@ -1841,15 +2207,24 @@ let link_reference_definition st : attributes Ast.link_def =
   let ws st =
     let rec loop seen_nl =
       match peek st with
-      | Some (' ' | '\t' | '\011'..'\013') -> junk st; loop seen_nl
-      | Some '\n' when not seen_nl -> junk st; loop true
-      | Some _ | None -> ()
+      | Some (' ' | '\t' | '\011' .. '\013') ->
+          junk st;
+          loop seen_nl
+      | Some '\n' when not seen_nl ->
+          junk st;
+          loop true
+      | Some _
+      | None ->
+          ()
     in
     loop false
   in
   let ws1 st =
     match next st with
-    | ' ' | '\t' | '\010'..'\013' -> ws st
+    | ' '
+    | '\t'
+    | '\010' .. '\013' ->
+        ws st
     | _ -> raise Fail
   in
   ignore (sp3 st);
@@ -1859,18 +2234,15 @@ let link_reference_definition st : attributes Ast.link_def =
   let destination = link_destination st in
   let attributes = inline_attribute_string st in
   match protect (ws1 >>> link_title <<< sp <<< eol) st with
-  | title ->
-      {label; destination; title = Some title; attributes}
+  | title -> { label; destination; title = Some title; attributes }
   | exception Fail ->
       (sp >>> eol) st;
-      {label; destination; title = None; attributes}
+      { label; destination; title = None; attributes }
 
 let link_reference_definitions st =
   let rec loop acc =
     match protect link_reference_definition st with
-    | def ->
-        loop (def :: acc)
-    | exception Fail ->
-        acc, pos st
+    | def -> loop (def :: acc)
+    | exception Fail -> (acc, pos st)
   in
   loop []

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -6,74 +6,72 @@ type t =
 
 let atom s = Atom s
 
-let rec link {label; destination; title; _} =
-  let title = match title with Some title -> [Atom title] | None -> [] in
+let rec link { label; destination; title; _ } =
+  let title =
+    match title with
+    | Some title -> [ Atom title ]
+    | None -> []
+  in
   List (Atom "link" :: inline label :: Atom destination :: title)
 
 and inline = function
-  | Concat (_, xs) ->
-      List (Atom "concat" :: List.map inline xs)
-  | Text (_, s) ->
-      Atom s
-  | Emph (_, il) ->
-      List [Atom "emph"; inline il]
-  | Strong (_, il) ->
-      List [Atom "strong"; inline il]
-  | Code _ ->
-      Atom "code"
-  | Hard_break _ ->
-      Atom "hard-break"
-  | Soft_break _->
-      Atom "soft-break"
-  | Link (_, def) ->
-      List [Atom "url"; link def]
-  | Html (_, s) ->
-      List [Atom "html"; Atom s]
-  | Image _ ->
-      Atom "img"
+  | Concat (_, xs) -> List (Atom "concat" :: List.map inline xs)
+  | Text (_, s) -> Atom s
+  | Emph (_, il) -> List [ Atom "emph"; inline il ]
+  | Strong (_, il) -> List [ Atom "strong"; inline il ]
+  | Code _ -> Atom "code"
+  | Hard_break _ -> Atom "hard-break"
+  | Soft_break _ -> Atom "soft-break"
+  | Link (_, def) -> List [ Atom "url"; link def ]
+  | Html (_, s) -> List [ Atom "html"; Atom s ]
+  | Image _ -> Atom "img"
 
 let rec block = function
-  | Paragraph (_, x) ->
-      List [Atom "paragraph"; inline x]
+  | Paragraph (_, x) -> List [ Atom "paragraph"; inline x ]
   | List (_, _, _, bls) ->
-      List (Atom "list" :: List.map (fun xs -> List (Atom "list-item" :: List.map block xs)) bls)
-  | Blockquote (_, xs) ->
-      List (Atom "blockquote" :: List.map block xs)
-  | Thematic_break _ ->
-      Atom "thematic-break"
+      List
+        (Atom "list"
+         ::
+         List.map (fun xs -> List (Atom "list-item" :: List.map block xs)) bls)
+  | Blockquote (_, xs) -> List (Atom "blockquote" :: List.map block xs)
+  | Thematic_break _ -> Atom "thematic-break"
   | Heading (_, level, text) ->
-      List [Atom "heading"; Atom (string_of_int level); inline text]
-  | Code_block (_, info, _) ->
-      List [Atom "code-block"; Atom info]
-  | Html_block (_, s) ->
-      List [Atom "html"; Atom s]
+      List [ Atom "heading"; Atom (string_of_int level); inline text ]
+  | Code_block (_, info, _) -> List [ Atom "code-block"; Atom info ]
+  | Html_block (_, s) -> List [ Atom "html"; Atom s ]
   | Definition_list (_, l) ->
-      List [Atom "def-list";
-            List (List.map (fun elt ->
-                List [inline elt.term;
-                      List (List.map inline elt.defs)]) l)]
+      List
+        [ Atom "def-list"
+        ; List
+            (List.map
+               (fun elt ->
+                 List [ inline elt.term; List (List.map inline elt.defs) ])
+               l)
+        ]
 
-let create ast =
-  List (List.map block ast)
+let create ast = List (List.map block ast)
 
 let needs_quotes s =
   let rec loop i =
     if i >= String.length s then
       false
-    else begin
+    else
       match s.[i] with
-      | ' ' | '\t' | '\x00'..'\x1F' | '\x7F'..'\x9F' ->
+      | ' '
+      | '\t'
+      | '\x00' .. '\x1F'
+      | '\x7F' .. '\x9F' ->
           true
-      | _ ->
-          loop (succ i)
-    end
+      | _ -> loop (succ i)
   in
   loop 0
 
 let rec print ppf = function
-  | Atom s when needs_quotes s ->
-      Format.fprintf ppf "%S" s
-  | Atom s ->
-      Format.pp_print_string ppf s
+  | Atom s when needs_quotes s -> Format.fprintf ppf "%S" s
+  | Atom s -> Format.pp_print_string ppf s
   | List l ->
-      Format.fprintf ppf "@[<1>(%a)@]" (Format.pp_print_list ~pp_sep:Format.pp_print_space print) l
+      Format.fprintf
+        ppf
+        "@[<1>(%a)@]"
+        (Format.pp_print_list ~pp_sep:Format.pp_print_space print)
+        l

--- a/src/toc.ml
+++ b/src/toc.ml
@@ -8,22 +8,27 @@ let rec remove_links inline =
   | Strong (attr, inline) -> Emph (attr, remove_links inline)
   | Link (_, link) -> link.label
   | Image (attr, link) ->
-      Image (attr, {link with label = remove_links link.label})
+      Image (attr, { link with label = remove_links link.label })
   | Hard_break _
   | Soft_break _
   | Html _
   | Code _
-  | Text _ -> inline
+  | Text _ ->
+      inline
 
 let headers =
   let remove_links_f = remove_links in
-  fun ?(remove_links=false) doc ->
+  fun ?(remove_links = false) doc ->
     let headers = ref [] in
     let rec loop blocks =
-      List.iter (function
+      List.iter
+        (function
           | Heading (attr, level, inline) ->
               let inline =
-                if remove_links then remove_links_f inline else inline
+                if remove_links then
+                  remove_links_f inline
+                else
+                  inline
               in
               headers := (attr, level, inline) :: !headers
           | Blockquote (_, blocks) -> loop blocks
@@ -32,8 +37,9 @@ let headers =
           | Thematic_break _
           | Html_block _
           | Definition_list _
-          | Code_block _ -> ()
-        ) blocks
+          | Code_block _ ->
+              ())
+        blocks
     in
     loop doc;
     List.rev !headers
@@ -47,27 +53,28 @@ let rec find_start headers level number subsections =
       (* Skip, right [level]-header not yet reached. *)
       if number = 0 then
         (* Assume empty section at [level], do not consume token. *)
-        (match subsections with
-         | [] -> headers (* no subsection to find *)
-         | n :: subsections -> find_start headers (level + 1) n subsections)
-      else find_start tl level number subsections
+        match subsections with
+        | [] -> headers (* no subsection to find *)
+        | n :: subsections -> find_start headers (level + 1) n subsections
+      else
+        find_start tl level number subsections
   | (_, header_level, _) :: tl when header_level = level ->
       (* At proper [level].  Have we reached the [number] one? *)
-      if number <= 1 then (
+      if number <= 1 then
         match subsections with
         | [] -> tl (* no subsection to find *)
         | n :: subsections -> find_start tl (level + 1) n subsections
-      )
-      else find_start tl level (number - 1) subsections
+      else
+        find_start tl level (number - 1) subsections
   | _ ->
       (* Sought [level] has not been found in the current section *)
       []
 
-let unordered_list items =
-  List ([], Bullet '*', Tight, items)
+let unordered_list items = List ([], Bullet '*', Tight, items)
 
 let find_id attributes =
-  List.find_map (function
+  List.find_map
+    (function
       | k, v when String.equal "id" k -> Some v
       | _ -> None)
     attributes
@@ -76,41 +83,48 @@ let link attributes label =
   let inline =
     match find_id attributes with
     | None -> label
-    | Some id -> Link([], {label; destination = "#" ^ id; title=None})
+    | Some id -> Link ([], { label; destination = "#" ^ id; title = None })
   in
   Paragraph ([], inline)
 
-let rec make_toc (headers: ('attr * int * 'a inline) list) ~min_level ~max_level =
+let rec make_toc
+    (headers : ('attr * int * 'a inline) list)
+    ~min_level
+    ~max_level =
   match headers with
-  | _ when min_level > max_level -> [], headers
-  | [] -> [], []
-  | (_, level, _) :: _ when level < min_level -> [], headers
-  | (_, level, _) :: tl when level > max_level ->  make_toc tl ~min_level ~max_level
+  | _ when min_level > max_level -> ([], headers)
+  | [] -> ([], [])
+  | (_, level, _) :: _ when level < min_level -> ([], headers)
+  | (_, level, _) :: tl when level > max_level ->
+      make_toc tl ~min_level ~max_level
   | (attr, level, t) :: tl when level = min_level ->
       let sub_toc, tl = make_toc tl ~min_level:(min_level + 1) ~max_level in
       let toc_entry =
         match sub_toc with
         | [] -> [ link attr t ]
-        | _ -> [ link attr t ; unordered_list sub_toc ]
+        | _ -> [ link attr t; unordered_list sub_toc ]
       in
       let toc, tl = make_toc tl ~min_level ~max_level in
-      toc_entry :: toc, tl
+      (toc_entry :: toc, tl)
   | _ ->
-      let sub_toc, tl = make_toc headers ~min_level:(min_level + 1) ~max_level in
+      let sub_toc, tl =
+        make_toc headers ~min_level:(min_level + 1) ~max_level
+      in
       let toc, tl = make_toc tl ~min_level ~max_level in
-      [unordered_list sub_toc] :: toc, tl
+      ([ unordered_list sub_toc ] :: toc, tl)
 
-let toc ?(start=[]) ?(depth=2) doc =
+let toc ?(start = []) ?(depth = 2) doc =
   if depth < 1 then invalid_arg "Omd.toc: ~depth must be >= 1";
   let headers = headers ~remove_links:true doc in
   let headers =
     match start with
     | [] -> headers
-    | number :: _ when number < 0 -> invalid_arg("Omd.toc: level 1 start must be >= 0");
+    | number :: _ when number < 0 ->
+        invalid_arg "Omd.toc: level 1 start must be >= 0"
     | number :: subsections -> find_start headers 1 number subsections
   in
   let len = List.length start in
-  let toc, _ = make_toc headers  ~min_level:(len + 1) ~max_level:(len + depth) in
+  let toc, _ = make_toc headers ~min_level:(len + 1) ~max_level:(len + depth) in
   match toc with
   | [] -> []
-  | _ -> [unordered_list toc]
+  | _ -> [ unordered_list toc ]

--- a/tests/dune
+++ b/tests/dune
@@ -6,10 +6,8 @@
 (rule
  (with-stdout-to
   dune.inc.new
-  (run ./extract_tests.exe -write-dune-file
-       %{dep:spec.txt}
-       %{dep:attributes.md}
-       %{dep:def_list.md})))
+  (run ./extract_tests.exe -write-dune-file %{dep:spec.txt}
+    %{dep:attributes.md} %{dep:def_list.md})))
 
 (include dune.inc)
 
@@ -20,4 +18,5 @@
 
 (rule
  (alias gen)
- (action (diff dune.inc dune.inc.new)))
+ (action
+  (diff dune.inc dune.inc.new)))

--- a/tests/extract_tests.ml
+++ b/tests/extract_tests.ml
@@ -1,55 +1,38 @@
 (* Extract test cases from Spec *)
 let protect ~finally f =
   match f () with
-  | exception e -> finally (); raise e
-  | r -> finally (); r
+  | exception e ->
+      finally ();
+      raise e
+  | r ->
+      finally ();
+      r
 
 let disabled =
-  [
-    175;
-    184;
-    185;
-    334;
-    410;
-    411;
-    414;
-    415;
-    416;
-    428;
-    468;
-    469;
-    516;
-    519;
-    536;
-  ]
+  [ 175; 184; 185; 334; 410; 411; 414; 415; 416; 428; 468; 469; 516; 519; 536 ]
 
 let with_open_in fn f =
   let ic = open_in fn in
-  protect ~finally:(fun () -> close_in_noerr ic)
-    (fun () -> f ic)
+  protect ~finally:(fun () -> close_in_noerr ic) (fun () -> f ic)
 
 let with_open_out fn f =
   let oc = open_out fn in
-  protect ~finally:(fun () -> close_out_noerr oc)
-    (fun () -> f oc)
+  protect ~finally:(fun () -> close_out_noerr oc) (fun () -> f oc)
 
 let begins_with s s' =
-  String.length s >= String.length s' &&
-  String.sub s 0 (String.length s') = s'
+  String.length s >= String.length s' && String.sub s 0 (String.length s') = s'
 
 let test_delim = "````````````````````````````````"
 
 let tab_re = Str.regexp_string "→"
 
-let insert_tabs s =
-  Str.global_replace tab_re "\t" s
+let insert_tabs s = Str.global_replace tab_re "\t" s
 
 type test =
-  {
-    filename: string;
-    example: int;
-    markdown: string;
-    html: string;
+  { filename : string
+  ; example : int
+  ; markdown : string
+  ; html : string
   }
 
 let add_line buf l =
@@ -61,8 +44,7 @@ let parse_test_spec filename =
   with_open_in filename @@ fun ic ->
   let rec go tests example =
     match input_line ic with
-    | exception End_of_file ->
-        List.rev tests
+    | exception End_of_file -> List.rev tests
     | line ->
         if begins_with line test_delim then begin
           Buffer.clear buf;
@@ -75,7 +57,7 @@ let parse_test_spec filename =
                 let line = input_line ic in
                 if begins_with line test_delim then
                   let html = Buffer.contents buf in
-                  {filename; example; markdown; html}
+                  { filename; example; markdown; html }
                 else begin
                   add_line buf line;
                   get_html ()
@@ -94,42 +76,59 @@ let parse_test_spec filename =
   go [] 1
 
 let write_dune_file test_specs tests =
-  let pp ppf {filename; example; _} =
+  let pp ppf { filename; example; _ } =
     let base = Filename.remove_extension filename in
     Format.fprintf ppf "@ %s-%03d.md %s-%03d.html" base example base example
   in
   Format.printf
-    "@[<v1>(rule@ @[<hov1>(deps %s)@]@ @[<v1>(targets%t)@]@ @[<hov1>(action@ (run ./extract_tests.exe -generate-test-files %%{deps}))@])@]@." (String.concat " " test_specs)
+    "@[<v1>(rule@ @[<hov1>(deps %s)@]@ @[<v1>(targets%t)@]@ @[<hov1>(action@ \
+     (run ./extract_tests.exe -generate-test-files %%{deps}))@])@]@."
+    (String.concat " " test_specs)
     (fun ppf -> List.iter (pp ppf) tests);
-  List.iter (fun {filename; example; _} ->
+  List.iter
+    (fun { filename; example; _ } ->
       let base = Filename.remove_extension filename in
       Format.printf
-        "@[<v1>(rule@ @[<hov1>(action@ @[<hov1>(with-stdout-to %s-%03d.html.new@ @[<hov1>(run@ ./omd.exe@ %%{dep:%s-%03d.md})@])@])@])@]@." base example base example;
+        "@[<v1>(rule@ @[<hov1>(action@ @[<hov1>(with-stdout-to \
+         %s-%03d.html.new@ @[<hov1>(run@ ./omd.exe@ \
+         %%{dep:%s-%03d.md})@])@])@])@]@."
+        base
+        example
+        base
+        example;
       Format.printf
-        "@[<v1>(rule@ @[<hov1>(alias %s-%03d)@]@ @[<hov1>(action@ @[<hov1>(diff@ %s-%03d.html %s-%03d.html.new)@])@])@]@." base example base example base example
-    ) tests;
-  let pp ppf {filename; example; _} =
+        "@[<v1>(rule@ @[<hov1>(alias %s-%03d)@]@ @[<hov1>(action@ \
+         @[<hov1>(diff@ %s-%03d.html %s-%03d.html.new)@])@])@]@."
+        base
+        example
+        base
+        example
+        base
+        example)
+    tests;
+  let pp ppf { filename; example; _ } =
     let base = Filename.remove_extension filename in
     if not (List.mem example disabled) then
-      Format.fprintf ppf "@ (alias %s-%03d)" base example in
+      Format.fprintf ppf "@ (alias %s-%03d)" base example
+  in
   Format.printf
     "@[<v1>(alias@ (name runtest)@ @[<v1>(deps%t)@])@]@."
     (fun ppf -> List.iter (pp ppf) tests)
 
 let li_begin_re = Str.regexp_string "<li>\n"
+
 let li_end_re = Str.regexp_string "\n</li>"
 
 let normalize_html s =
-  Str.global_replace li_end_re "</li>"
-    (Str.global_replace li_begin_re "<li>" s)
+  Str.global_replace li_end_re "</li>" (Str.global_replace li_begin_re "<li>" s)
 
 let generate_test_files tests =
-  let f {filename; example; markdown; html} =
+  let f { filename; example; markdown; html } =
     let base = Filename.remove_extension filename in
-    with_open_out (Printf.sprintf "%s-%03d.md" base example)
-      (fun oc -> output_string oc markdown);
-    with_open_out (Printf.sprintf "%s-%03d.html" base example)
-      (fun oc -> output_string oc (normalize_html html))
+    with_open_out (Printf.sprintf "%s-%03d.md" base example) (fun oc ->
+        output_string oc markdown);
+    with_open_out (Printf.sprintf "%s-%03d.html" base example) (fun oc ->
+        output_string oc (normalize_html html))
   in
   List.iter f tests
 
@@ -141,9 +140,10 @@ let mode = ref None
 
 let spec =
   let set x () = mode := Some x in
-  [
-    "-generate-test-files", Arg.Unit (set Generate_test_files), " Generate test files";
-    "-write-dune-file", Arg.Unit (set Write_dune_file), " Write dune file";
+  [ ( "-generate-test-files"
+    , Arg.Unit (set Generate_test_files)
+    , " Generate test files" )
+  ; ("-write-dune-file", Arg.Unit (set Write_dune_file), " Write dune file")
   ]
 
 let test_specs = ref []

--- a/tests/omd.ml
+++ b/tests/omd.ml
@@ -1,18 +1,22 @@
 let protect ~finally f =
   match f () with
-  | exception e -> finally (); raise e
-  | r -> finally (); r
+  | exception e ->
+      finally ();
+      raise e
+  | r ->
+      finally ();
+      r
+
 let li_begin_re = Str.regexp_string "<li>\n"
+
 let li_end_re = Str.regexp_string "\n</li>"
 
 let normalize_html s =
-  Str.global_replace li_end_re "</li>"
-    (Str.global_replace li_begin_re "<li>" s)
+  Str.global_replace li_end_re "</li>" (Str.global_replace li_begin_re "<li>" s)
 
 let with_open_in fn f =
   let ic = open_in fn in
-  protect ~finally:(fun () -> close_in_noerr ic)
-    (fun () -> f ic)
+  protect ~finally:(fun () -> close_in_noerr ic) (fun () -> f ic)
 
 let () =
   with_open_in Sys.argv.(1) @@ fun ic ->

--- a/tools/gen_entities.ml
+++ b/tools/gen_entities.ml
@@ -1,23 +1,28 @@
 let f s =
-  Scanf.sscanf s " \"&%s@;\": { %_S: [%s@], %_S: \"%_s@\" }"
-    (fun s nums ->
-       s, List.map (fun s -> int_of_string (String.trim s)) (String.split_on_char ',' nums))
+  Scanf.sscanf s " \"&%s@;\": { %_S: [%s@], %_S: \"%_s@\" }" (fun s nums ->
+      ( s
+      , List.map
+          (fun s -> int_of_string (String.trim s))
+          (String.split_on_char ',' nums) ))
 
 let main ic =
   let rec loop () =
     match input_line ic with
     | s ->
-        begin match f s with
-        | name, codepoints ->
-            Printf.printf "  | %S -> [" name;
-            List.iteri (fun i cp -> if i > 0 then print_string "; "; Printf.printf "Uchar.of_int %d" cp) codepoints;
-            Printf.printf "]\n"
-        | exception _ ->
-            ()
+        begin
+          match f s with
+          | name, codepoints ->
+              Printf.printf "  | %S -> [" name;
+              List.iteri
+                (fun i cp ->
+                  if i > 0 then print_string "; ";
+                  Printf.printf "Uchar.of_int %d" cp)
+                codepoints;
+              Printf.printf "]\n"
+          | exception _ -> ()
         end;
         loop ()
-    | exception End_of_file ->
-        Printf.printf "  | _ -> []\n%!"
+    | exception End_of_file -> Printf.printf "  | _ -> []\n%!"
   in
   Printf.printf "let f = function\n";
   loop ()


### PR DESCRIPTION
- Add an `.ocamlformat` config
- Reformat code base
- CI pipeline updates
  - Use github actions v2
  - Run formatting check
  - Add missing compiler versions
  - Enable dune-cache

I'll wait to merge this until #232 (and other substantial outstanding PRs?) are merged in.

In the meantime, @sonologico, whenever you have a chance, let me know if you are OK with these formatting, or if you have strong feelings by a different config.