### PR TITLE
Upgrade to ocamlformat.0.19.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.18.0
+version = 0.19.0
 exp-grouping = preserve
 break-fun-sig = fit-or-vertical
 break-fun-decl = fit-or-vertical

--- a/README.md
+++ b/README.md
@@ -77,3 +77,4 @@ Sheets](https://github.com/dsheets/), [Jeremy
 Yallop](https://github.com/yallop/), and \<please insert your name here if you
 believe you've been forgotten\> for their feedbacks and contributions to this
 project.
+

--- a/README.md
+++ b/README.md
@@ -77,4 +77,3 @@ Sheets](https://github.com/dsheets/), [Jeremy
 Yallop](https://github.com/yallop/), and \<please insert your name here if you
 believe you've been forgotten\> for their feedbacks and contributions to this
 project.
-

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -31,8 +31,8 @@ let rec block = function
   | List (_, _, _, bls) ->
       List
         (Atom "list"
-         ::
-         List.map (fun xs -> List (Atom "list-item" :: List.map block xs)) bls)
+        :: List.map (fun xs -> List (Atom "list-item" :: List.map block xs)) bls
+        )
   | Blockquote (_, xs) -> List (Atom "blockquote" :: List.map block xs)
   | Thematic_break _ -> Atom "thematic-break"
   | Heading (_, level, text) ->

--- a/src/toc.ml
+++ b/src/toc.ml
@@ -46,7 +46,7 @@ let headers =
 
 (* Given a list of headers — in the order of the document — go to the
    requested subsection.  We first seek for the [number]th header at
-   [level].  *)
+   [level]. *)
 let rec find_start headers level number subsections =
   match headers with
   | (_, header_level, _) :: tl when header_level > level ->


### PR DESCRIPTION
This is a preview of the not-yet-released `ocamlformat.0.19.0`, please wait until the package is published in opam to merge this PR. The output is still likely to slightly change before the package is released.