### PR TITLE
Add regression test for #224

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,8 @@
-(lang dune 2.0)
-
+(lang dune 2.7)
 (name omd)
 (version 2.0.0~alpha1)
+
+(cram enable)
 
 (generate_opam_files)
 

--- a/tests/blackbox/dune
+++ b/tests/blackbox/dune
@@ -1,0 +1,2 @@
+(cram
+ (deps %{bin:omd}))

--- a/tests/blackbox/regression-224.t
+++ b/tests/blackbox/regression-224.t
@@ -1,0 +1,11 @@
+Regression test for https://github.com/ocaml/omd/issues/224
+
+  $ omd << "MD"
+  > hello_world:
+  > ```
+  > is_this_code_
+  > ```
+  > MD
+  <p>hello_world:</p>
+  <pre><code>is_this_code_
+  </code></pre>


### PR DESCRIPTION
Closes #224 

This also bumps our dune lang version up to 2.7, which reverses course from #218,  originally motivated by #212.

See  c3d151e for the rationale. 

This bears upon one aspect of the testing question that came up at #248. @sonologico how do you feel about adopting Dune's built in support for cram-style tests, as I'm doing here, for our end-to-end testing setup?