### PR TITLE
[Preview] upgrade to ocamlformat.0.20.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,5 @@
-version = 0.19.0
+version = 0.20.0
+profile = conventional
 exp-grouping = preserve
 break-fun-sig = fit-or-vertical
 break-fun-decl = fit-or-vertical

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -23,7 +23,6 @@ let process ic oc =
   output_string oc (Omd.to_html md)
 
 let input = ref []
-
 let output = ref ""
 
 let spec =

--- a/src/block.ml
+++ b/src/block.ml
@@ -89,7 +89,6 @@ module Pre = struct
   and finish link_defs state = List.rev (close link_defs state)
 
   let empty = { blocks = []; next = Rempty }
-
   let classify_line s = Parser.parse s
 
   let rec process link_defs { blocks; next } s =

--- a/src/html.ml
+++ b/src/html.ml
@@ -12,9 +12,7 @@ type t =
   | Concat of t * t
 
 let elt etype name attrs childs = Element (etype, name, attrs, childs)
-
 let text s = Text s
-
 let raw s = Raw s
 
 let concat t1 t2 =

--- a/src/html.mli
+++ b/src/html.mli
@@ -12,5 +12,4 @@ type t =
   | Concat of t * t
 
 val of_doc : attributes block list -> t
-
 val to_string : t -> string

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -15,13 +15,8 @@ let parse_inlines (md, defs) =
   List.map (Mapper.map (parse_inline defs)) md
 
 let of_channel ic = parse_inlines (Pre.of_channel ic)
-
 let of_string s = parse_inlines (Pre.of_string s)
-
 let to_html doc = Html.to_string (Html.of_doc doc)
-
 let to_sexp ast = Format.asprintf "@[%a@]@." Sexp.print (Sexp.create ast)
-
 let headers = Toc.headers
-
 let toc = Toc.toc

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -47,11 +47,8 @@ type doc = attributes block list
 (** A markdown document *)
 
 val of_channel : in_channel -> doc
-
 val of_string : string -> doc
-
 val to_html : doc -> string
-
 val to_sexp : doc -> string
 
 val headers :

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -5,33 +5,19 @@ module Sub : sig
   type t
 
   val of_string : string -> t
-
   val to_string : t -> string
-
   val offset : int -> t -> t
-
   val lexbuf : t -> Lexing.lexbuf
-
   val contains : string -> t -> bool
-
   val print : Format.formatter -> t -> unit
-
   val head : ?rev:unit -> t -> char option
-
   val tail : ?rev:unit -> t -> t
-
   val heads : int -> t -> char list
-
   val tails : int -> t -> t
-
   val for_all : (char -> bool) -> t -> bool
-
   val exists : (char -> bool) -> t -> bool
-
   val is_empty : t -> bool
-
   val length : t -> int
-
   val sub : len:int -> t -> t
 end = struct
   type t =
@@ -41,11 +27,8 @@ end = struct
     }
 
   let of_string base = { base; off = 0; len = String.length base }
-
   let to_string { base; off; len } = String.sub base off len
-
   let print ppf s = Format.fprintf ppf "%S" (to_string s)
-
   let length { len; _ } = len
 
   let offset n { base; off; len } =
@@ -137,45 +120,26 @@ exception Fail
 
 module P : sig
   type state
-
   type 'a t = state -> 'a
 
   val of_string : string -> state
-
   val peek : char option t
-
   val peek_exn : char t
-
   val pos : state -> int
-
   val range : state -> int -> int -> string
-
   val set_pos : state -> int -> unit
-
   val junk : unit t
-
   val char : char -> unit t
-
   val next : char t
-
   val ( ||| ) : 'a t -> 'a t -> 'a t
-
   val ws : unit t
-
   val sp : unit t
-
   val ws1 : unit t
-
   val ( >>> ) : unit t -> 'a t -> 'a t
-
   val ( <<< ) : 'a t -> unit t -> 'a t
-
   val protect : 'a t -> 'a t
-
   val peek_before : char -> state -> char
-
   val peek_after : char -> state -> char
-
   val pair : 'a t -> 'b t -> ('a * 'b) t
 end = struct
   type state =
@@ -225,11 +189,8 @@ end = struct
       st.str.[st.pos + 1]
 
   let pos st = st.pos
-
   let range st pos n = String.sub st.str pos n
-
   let set_pos st pos = st.pos <- pos
-
   let junk st = if st.pos < String.length st.str then st.pos <- st.pos + 1
 
   let protect p st =
@@ -1483,7 +1444,6 @@ let option d p st =
   | exception Fail -> d
 
 let some p st = Some (p st)
-
 let attribute_value_specification = ws >>> char '=' >>> ws >>> attribute_value
 
 let ws1_buf buf st =

--- a/tests/extract_tests.ml
+++ b/tests/extract_tests.ml
@@ -23,9 +23,7 @@ let begins_with s s' =
   String.length s >= String.length s' && String.sub s 0 (String.length s') = s'
 
 let test_delim = "````````````````````````````````"
-
 let tab_re = Str.regexp_string "→"
-
 let insert_tabs s = Str.global_replace tab_re "\t" s
 
 type test =
@@ -116,7 +114,6 @@ let write_dune_file test_specs tests =
     (fun ppf -> List.iter (pp ppf) tests)
 
 let li_begin_re = Str.regexp_string "<li>\n"
-
 let li_end_re = Str.regexp_string "\n</li>"
 
 let normalize_html s =
@@ -147,7 +144,6 @@ let spec =
   ]
 
 let test_specs = ref []
-
 let add_to_list l x = l := x :: !l
 
 let () =

--- a/tests/omd.ml
+++ b/tests/omd.ml
@@ -8,7 +8,6 @@ let protect ~finally f =
       r
 
 let li_begin_re = Str.regexp_string "<li>\n"
-
 let li_end_re = Str.regexp_string "\n</li>"
 
 let normalize_html s =


### PR DESCRIPTION
This is a preview of the not-yet-released `ocamlformat.0.20.0`, please wait until the package is published in opam to merge this PR. The output is still likely to slightly change before the package is released.
The changes are due to:
- `module-item-spacing` is now set to `compact` for the default profile
- `module-item-spacing` is now correctly applied to mutually recursive type definitions