### PR TITLE
Make definitions block-level

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -22,14 +22,14 @@ end
 module MakeBlock (I : T) = struct
   type 'attr def_elt =
     { term : 'attr I.t
-    ; defs : 'attr I.t list
+    ; defs : 'attr block list list
     }
 
   (* A value of type 'attr is present in all variants of this type. We use it to associate
      extra information to each node in the AST. In the common case, the attributes type defined
      above is used. We might eventually have an alternative function to parse blocks while keeping
      concrete information such as source location and we'll use it for that as well. *)
-  type 'attr block =
+  and 'attr block =
     | Paragraph of 'attr * 'attr I.t
     | List of 'attr * list_type * list_spacing * 'attr block list list
     | Blockquote of 'attr * 'attr block list
@@ -37,7 +37,7 @@ module MakeBlock (I : T) = struct
     | Heading of 'attr * int * 'attr I.t
     | Code_block of 'attr * string * string
     | Html_block of 'attr * string
-    | Definition_list of 'attr * 'attr def_elt list
+    | Definition_list of 'attr * list_spacing * 'attr def_elt list
 end
 
 type 'attr link =
@@ -83,11 +83,11 @@ module MakeMapper (Src : T) (Dst : T) = struct
     | Blockquote (attr, xs) -> Blockquote (attr, List.map (map f) xs)
     | Thematic_break attr -> Thematic_break attr
     | Heading (attr, level, text) -> Heading (attr, level, f text)
-    | Definition_list (attr, l) ->
+    | Definition_list (attr, sp, l) ->
         let f { SrcBlock.term; defs } =
-          { DstBlock.term = f term; defs = List.map f defs }
+          { DstBlock.term = f term; defs = List.map (List.map (map f)) defs }
         in
-        Definition_list (attr, List.map f l)
+        Definition_list (attr, sp, List.map f l)
     | Code_block (attr, label, code) -> Code_block (attr, label, code)
     | Html_block (attr, x) -> Html_block (attr, x)
 end

--- a/src/html.ml
+++ b/src/html.ml
@@ -196,11 +196,16 @@ let rec block = function
         | _ -> "p"
       in
       elt Block name attr (Some (inline text))
-  | Definition_list (attr, l) ->
+  | Definition_list (attr, sp, l) ->
+      let block' t =
+        match (t, sp) with
+        | Paragraph (_, t), Tight -> concat (inline t) nl
+        | _ -> block t
+      in
       let f { term; defs } =
         concat
           (elt Block "dt" [] (Some (inline term)))
-          (concat_map (fun s -> elt Block "dd" [] (Some (inline s))) defs)
+          (concat_map (fun s -> elt Block "dd" [] (Some (concat nl (concat_map block' s)))) defs)
       in
       elt Block "dl" attr (Some (concat_map f l))
 

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -30,10 +30,10 @@ and 'attr inline =
 
 type 'attr def_elt =
   { term : 'attr inline
-  ; defs : 'attr inline list
+  ; defs : 'attr block list list
   }
 
-type 'attr block =
+and 'attr block =
   | Paragraph of 'attr * 'attr inline
   | List of 'attr * list_type * list_spacing * 'attr block list list
   | Blockquote of 'attr * 'attr block list
@@ -41,7 +41,7 @@ type 'attr block =
   | Heading of 'attr * int * 'attr inline
   | Code_block of 'attr * string * string
   | Html_block of 'attr * string
-  | Definition_list of 'attr * 'attr def_elt list
+  | Definition_list of 'attr * list_spacing * 'attr def_elt list
 
 type doc = attributes block list
 (** A markdown document *)

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -311,7 +311,7 @@ type t =
   | Lhtml of bool * html_kind
   | Llist_item of list_type * int * Sub.t
   | Lparagraph
-  | Ldef_list of string
+  | Ldef_list of int * string
 
 let sp3 s =
   match Sub.head s with
@@ -959,11 +959,11 @@ let tag_string s =
   in
   loop (ws s)
 
-let def_list s =
+let def_list ind s =
   let s = Sub.tail s in
   match Sub.head s with
   | Some (' ' | '\t' | '\010' .. '\013') ->
-      Ldef_list (String.trim (Sub.to_string s))
+      Ldef_list (ind + 2, String.trim (Sub.to_string s))
   | _ -> raise Fail
 
 let indented_code ind s =
@@ -992,7 +992,7 @@ let parse s0 =
   | Some '*' -> (thematic_break ||| unordered_list_item ind) s
   | Some '+' -> unordered_list_item ind s
   | Some '0' .. '9' -> ordered_list_item ind s
-  | Some ':' -> def_list s
+  | Some ':' -> def_list ind s
   | Some _ -> (blank ||| indented_code ind) s
   | None -> Lempty
 

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -39,13 +39,13 @@ let rec block = function
       List [ Atom "heading"; Atom (string_of_int level); inline text ]
   | Code_block (_, info, _) -> List [ Atom "code-block"; Atom info ]
   | Html_block (_, s) -> List [ Atom "html"; Atom s ]
-  | Definition_list (_, l) ->
+  | Definition_list (_, _, l) ->
       List
         [ Atom "def-list"
         ; List
             (List.map
                (fun elt ->
-                 List [ inline elt.term; List (List.map inline elt.defs) ])
+                  List [ inline elt.term; List (List.map (fun def -> List (List.map block def)) elt.defs) ])
                l)
         ]
 

--- a/tests/def_list.md
+++ b/tests/def_list.md
@@ -10,13 +10,80 @@ Second Term
 which is multiline
 
 : This is not a correct definition list
+
+# With multiple paragraphs
+
+First Term
+: This is the definition of the first term.
+
+Second Term
+: This is one paragraph of the second term.
+
+  This is another paragraph of the second term.
+
+# Nesting
+
+Root
+: Level one
+
+  Nested
+  : Level two
+    ```
+    code
+    ```
+
+    More
+    : Level three
+
+Root again
+: Level one again
+
 .
 <dl><dt>First Term</dt>
-<dd>This is the definition of the first term.</dd>
+<dd>
+This is the definition of the first term.
+</dd>
 <dt>Second Term</dt>
-<dd>This is one definition of the second term.</dd>
-<dd>This is another definition of the second term.
-which is multiline</dd>
+<dd>
+This is one definition of the second term.
+</dd>
+<dd>
+This is another definition of the second term.
+which is multiline
+</dd>
 </dl>
 <p>: This is not a correct definition list</p>
+<h1>With multiple paragraphs</h1>
+<dl><dt>First Term</dt>
+<dd>
+<p>This is the definition of the first term.</p>
+</dd>
+<dt>Second Term</dt>
+<dd>
+<p>This is one paragraph of the second term.</p>
+<p>This is another paragraph of the second term.</p>
+</dd>
+</dl>
+<h1>Nesting</h1>
+<dl><dt>Root</dt>
+<dd>
+<p>Level one</p>
+<dl><dt>Nested</dt>
+<dd>
+<p>Level two</p>
+<pre><code>code
+</code></pre>
+<dl><dt>More</dt>
+<dd>
+Level three
+</dd>
+</dl>
+</dd>
+</dl>
+</dd>
+<dt>Root again</dt>
+<dd>
+<p>Level one again</p>
+</dd>
+</dl>
 ````````````````````````````````


### PR DESCRIPTION
I just converted my blog from Octopress to omd, and I needed support for definition lists with multiple paragraphs.

Not completely sure what I'm doing here, but this changed got it working it for me, and should go some way towards #221.