### PR TITLE
Preserve order of input file list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+unreleased
+----------
+
+- Preserve the order of input files in the HTML output to stdout (#258,
+  @patricoferris)
+
 2.0.0~alpha2
 ------------
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -51,7 +51,7 @@ let main () =
     process stdin oc
   else
     let f filename = with_open_in filename @@ fun ic -> process ic oc in
-    List.iter f !input
+    List.(iter f (rev !input))
 
 let () =
   try main () with


### PR DESCRIPTION
I've been working on something that uses the `omd` binary to provide a text-only version of the markdown as a standalone html page and noticed `omd x y z` outputs HTML to `stdout` in the order `z y x`, I tried `omd.1.3.1` and it outputs the HTML in the same order the files were given which I think is the more expected behaviour.