### PR TITLE
Fix spec 519. Reprocess inlines in case a label turns out to not be for a link

### DIFF
--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1964,16 +1964,15 @@ let rec inline defs st =
     let off0 = pos st in
     match protect (link_label true) st with
     | lab -> (
-        let off1 = pos st in
-        let lab1 = inline defs (of_string lab) in
-        let reflink lab' =
-          let s = normalize lab' in
+        let reflink lab =
+          let s = normalize lab in
           match
             List.find_opt
               (fun ({ label; _ } : attributes link_def) -> label = s)
               defs
           with
           | Some { label = _; destination; title; attributes = attr } ->
+              let lab1 = inline defs (of_string lab) in
               let r =
                 let def = { label = lab1; destination; title } in
                 match kind with
@@ -1984,9 +1983,8 @@ let rec inline defs st =
           | None ->
               if kind = Img then Buffer.add_char buf '!';
               Buffer.add_char buf '[';
-              let acc = Pre.R lab1 :: text acc in
-              Buffer.add_char buf ']';
-              set_pos st off1;
+              let acc = text acc in
+              set_pos st (succ off0);
               loop acc st
         in
         match peek st with

--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -5181,6 +5181,7 @@
   (alias spec-515)
   (alias spec-517)
   (alias spec-518)
+  (alias spec-519)
   (alias spec-520)
   (alias spec-521)
   (alias spec-522)

--- a/tests/extract_tests.ml
+++ b/tests/extract_tests.ml
@@ -9,7 +9,7 @@ let protect ~finally f =
       r
 
 let disabled =
-  [ 175; 184; 185; 334; 410; 411; 414; 415; 416; 428; 468; 469; 516; 519; 536 ]
+  [ 175; 184; 185; 334; 410; 411; 414; 415; 416; 428; 468; 469; 516; 536 ]
 
 let with_open_in fn f =
   let ic = open_in fn in


### PR DESCRIPTION
I'll double check if my intuition is correct, but this fixes the test.

What was happening is that we would process the inline content of the (would be) label and use the results even if it didn't turn out to be a label. However, because one `*` was between brackets and the other `*` was outside, they were never matched and therefore treated as text.