### PR TITLE
Spec 334: Preserve spaces in inline code blocks consisting of spaces only

### DIFF
--- a/src/compat.ml
+++ b/src/compat.ml
@@ -51,8 +51,12 @@ module String = struct
   let for_all p s =
     let n = length s in
     let rec loop i =
-      if i = n then true
-      else if p (unsafe_get s i) then loop (succ i)
-      else false in
+      if i = n then
+        true
+      else if p (unsafe_get s i) then
+        loop (succ i)
+      else
+        false
+    in
     loop 0
 end

--- a/src/compat.ml
+++ b/src/compat.ml
@@ -44,3 +44,15 @@ module Buffer = struct
         Buffer.add_char b (Char.unsafe_chr (0x80 lor (u land 0x3F)))
     | _ -> assert false
 end
+
+module String = struct
+  include String
+
+  let for_all p s =
+    let n = length s in
+    let rec loop i =
+      if i = n then true
+      else if p (unsafe_get s i) then loop (succ i)
+      else false in
+    loop 0
+end

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1910,9 +1910,7 @@ let inline_pre buf acc st =
         let finish () =
           let content = Buffer.contents bufcode in
           let content =
-            if
-              String.for_all (fun c -> c = ' ') content
-            then
+            if String.for_all (fun c -> c = ' ') content then
               content
             else if
               String.length content >= 2

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1911,10 +1911,13 @@ let inline_pre buf acc st =
           let content = Buffer.contents bufcode in
           let content =
             if
+              String.for_all (fun c -> c = ' ') content
+            then
+              content
+            else if
               String.length content >= 2
               && content.[0] = ' '
               && content.[String.length content - 1] = ' '
-              (* FIXME not fully whitespace *)
             then
               String.sub content 1 (String.length content - 2)
             else

--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -5006,6 +5006,7 @@
   (alias spec-331)
   (alias spec-332)
   (alias spec-333)
+  (alias spec-334)
   (alias spec-335)
   (alias spec-336)
   (alias spec-337)

--- a/tests/extract_tests.ml
+++ b/tests/extract_tests.ml
@@ -9,7 +9,7 @@ let protect ~finally f =
       r
 
 let disabled =
-  [ 175; 184; 185; 334; 410; 411; 414; 415; 416; 428; 468; 469; 516; 536 ]
+  [ 175; 184; 185; 410; 411; 414; 415; 416; 428; 468; 469; 516; 536 ]
 
 let with_open_in fn f =
   let ic = open_in fn in


### PR DESCRIPTION
Fixes #243 