### PR TITLE
Ocamlformat 0.21.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,12 +1,9 @@
-version = 0.19.0
+version = 0.21.0
 exp-grouping = preserve
 break-fun-sig = fit-or-vertical
 break-fun-decl = fit-or-vertical
 wrap-fun-args = false
 dock-collection-brackets = false
-break-cases = all
 break-separators = before
 break-infix = fit-or-vertical
-if-then-else = k-r
-nested-match = align
 type-decl = sparse

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -23,7 +23,6 @@ let process ic oc =
   output_string oc (Omd.to_html md)
 
 let input = ref []
-
 let output = ref ""
 
 let spec =
@@ -41,14 +40,10 @@ let main () =
     (fun s -> input := s :: !input)
     "omd [options] [inputfile1 .. inputfileN] [options]";
   let with_output f =
-    if !output = "" then
-      f stdout
-    else
-      with_open_out !output f
+    if !output = "" then f stdout else with_open_out !output f
   in
   with_output @@ fun oc ->
-  if !input = [] then
-    process stdin oc
+  if !input = [] then process stdin oc
   else
     let f filename = with_open_in filename @@ fun ic -> process ic oc in
     List.(iter f (rev !input))

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -96,7 +96,5 @@ module Mapper = MakeMapper (StringT) (InlineT)
 
 let same_block_list_kind k1 k2 =
   match (k1, k2) with
-  | Ordered (_, c1), Ordered (_, c2)
-  | Bullet c1, Bullet c2 ->
-      c1 = c2
+  | Ordered (_, c1), Ordered (_, c2) | Bullet c1, Bullet c2 -> c1 = c2
   | _ -> false

--- a/src/block.ml
+++ b/src/block.ml
@@ -33,20 +33,11 @@ module Pre = struct
 
   let trim_left s =
     let rec loop i =
-      if i >= String.length s then
-        i
-      else
-        match s.[i] with
-        | ' '
-        | '\t' ->
-            loop (succ i)
-        | _ -> i
+      if i >= String.length s then i
+      else match s.[i] with ' ' | '\t' -> loop (succ i) | _ -> i
     in
     let i = loop 0 in
-    if i > 0 then
-      String.sub s i (String.length s - i)
-    else
-      s
+    if i > 0 then String.sub s i (String.length s - i) else s
 
   let rec close link_defs { blocks; next } =
     let finish = finish link_defs in
@@ -61,10 +52,7 @@ module Pre = struct
         in
         let s = String.sub s off (String.length s - off) |> String.trim in
         link_defs := defs @ !link_defs;
-        if s = "" then
-          blocks
-        else
-          Paragraph ([], s) :: blocks
+        if s = "" then blocks else Paragraph ([], s) :: blocks
     | Rfenced_code (_, _, _kind, (label, _other), [], attr) ->
         Code_block (attr, label, "") :: blocks
     | Rfenced_code (_, _, _kind, (label, _other), l, attr) ->
@@ -78,10 +66,7 @@ module Pre = struct
         Definition_list ([], l @ [ { term; defs = List.rev defs } ]) :: blocks
     | Rindented_code l ->
         (* TODO: trim from the right *)
-        let rec loop = function
-          | "" :: l -> loop l
-          | _ as l -> l
-        in
+        let rec loop = function "" :: l -> loop l | _ as l -> l in
         Code_block ([], "", concat (loop l)) :: blocks
     | Rhtml (_, l) -> Html_block ([], concat l) :: blocks
     | Rempty -> blocks
@@ -89,7 +74,6 @@ module Pre = struct
   and finish link_defs state = List.rev (close link_defs state)
 
   let empty = { blocks = []; next = Rempty }
-
   let classify_line s = Parser.parse s
 
   let rec process link_defs { blocks; next } s =
@@ -139,10 +123,7 @@ module Pre = struct
     | Rfenced_code (ind, num, q, info, lines, a), _ ->
         let s =
           let ind = min (Parser.indent s) ind in
-          if ind > 0 then
-            Sub.offset ind s
-          else
-            s
+          if ind > 0 then Sub.offset ind s else s
         in
         { blocks
         ; next = Rfenced_code (ind, num, q, info, Sub.to_string s :: lines, a)
@@ -195,21 +176,13 @@ module Pre = struct
                 true
             | _ -> false
           in
-          if prev_empty && new_block state.next then
-            Loose
-          else
-            style
+          if prev_empty && new_block state.next then Loose else style
         in
         { blocks; next = Rlist (kind, style, false, ind, items, state) }
     | ( Rlist (kind, style, prev_empty, _, items, state)
       , Llist_item (kind', ind, s) )
       when same_block_list_kind kind kind' ->
-        let style =
-          if prev_empty then
-            Loose
-          else
-            style
-        in
+        let style = if prev_empty then Loose else style in
         { blocks
         ; next =
             Rlist
@@ -230,8 +203,7 @@ module Pre = struct
               | None -> None)
           | Rparagraph (_ :: _ as lines) -> (
               match classify_line s with
-              | Parser.Lparagraph
-              | Lindented_code _
+              | Parser.Lparagraph | Lindented_code _
               | Lsetext_heading (1, _)
               | Lhtml (false, _) ->
                   Some (Rparagraph (Sub.to_string s :: lines))
@@ -258,8 +230,7 @@ module Pre = struct
   let read_line s off =
     let buf = Buffer.create 128 in
     let rec loop cr_read off =
-      if off >= String.length s then
-        (Buffer.contents buf, None)
+      if off >= String.length s then (Buffer.contents buf, None)
       else
         match s.[off] with
         | '\n' -> (Buffer.contents buf, Some (succ off))

--- a/src/compat.ml
+++ b/src/compat.ml
@@ -9,18 +9,11 @@ module List = struct
 
   let rec find_map f = function
     | [] -> None
-    | x :: xs ->
-    match f x with
-    | None -> find_map f xs
-    | y -> y
+    | x :: xs -> ( match f x with None -> find_map f xs | y -> y)
 
   let rec find_opt p = function
     | [] -> None
-    | x :: l ->
-        if p x then
-          Some x
-        else
-          find_opt p l
+    | x :: l -> if p x then Some x else find_opt p l
 end
 
 module Buffer = struct
@@ -51,12 +44,9 @@ module String = struct
   let for_all p s =
     let n = length s in
     let rec loop i =
-      if i = n then
-        true
-      else if p (unsafe_get s i) then
-        loop (succ i)
-      else
-        false
+      if i = n then true
+      else if p (unsafe_get s i) then loop (succ i)
+      else false
     in
     loop 0
 end

--- a/src/html.mli
+++ b/src/html.mli
@@ -12,5 +12,4 @@ type t =
   | Concat of t * t
 
 val of_doc : attributes block list -> t
-
 val to_string : t -> string

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -15,13 +15,8 @@ let parse_inlines (md, defs) =
   List.map (Mapper.map (parse_inline defs)) md
 
 let of_channel ic = parse_inlines (Pre.of_channel ic)
-
 let of_string s = parse_inlines (Pre.of_string s)
-
 let to_html doc = Html.to_string (Html.of_doc doc)
-
 let to_sexp ast = Format.asprintf "@[%a@]@." Sexp.print (Sexp.create ast)
-
 let headers = Toc.headers
-
 let toc = Toc.toc

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -47,11 +47,8 @@ type doc = attributes block list
 (** A markdown document *)
 
 val of_channel : in_channel -> doc
-
 val of_string : string -> doc
-
 val to_html : doc -> string
-
 val to_sexp : doc -> string
 
 val headers :

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -7,11 +7,7 @@ type t =
 let atom s = Atom s
 
 let rec link { label; destination; title; _ } =
-  let title =
-    match title with
-    | Some title -> [ Atom title ]
-    | None -> []
-  in
+  let title = match title with Some title -> [ Atom title ] | None -> [] in
   List (Atom "link" :: inline label :: Atom destination :: title)
 
 and inline = function
@@ -53,15 +49,10 @@ let create ast = List (List.map block ast)
 
 let needs_quotes s =
   let rec loop i =
-    if i >= String.length s then
-      false
+    if i >= String.length s then false
     else
       match s.[i] with
-      | ' '
-      | '\t'
-      | '\x00' .. '\x1F'
-      | '\x7F' .. '\x9F' ->
-          true
+      | ' ' | '\t' | '\x00' .. '\x1F' | '\x7F' .. '\x9F' -> true
       | _ -> loop (succ i)
   in
   loop 0

--- a/src/toc.ml
+++ b/src/toc.ml
@@ -9,12 +9,7 @@ let rec remove_links inline =
   | Link (_, link) -> link.label
   | Image (attr, link) ->
       Image (attr, { link with label = remove_links link.label })
-  | Hard_break _
-  | Soft_break _
-  | Html _
-  | Code _
-  | Text _ ->
-      inline
+  | Hard_break _ | Soft_break _ | Html _ | Code _ | Text _ -> inline
 
 let headers =
   let remove_links_f = remove_links in
@@ -25,18 +20,12 @@ let headers =
         (function
           | Heading (attr, level, inline) ->
               let inline =
-                if remove_links then
-                  remove_links_f inline
-                else
-                  inline
+                if remove_links then remove_links_f inline else inline
               in
               headers := (attr, level, inline) :: !headers
           | Blockquote (_, blocks) -> loop blocks
           | List (_, _, _, block_lists) -> List.iter loop block_lists
-          | Paragraph _
-          | Thematic_break _
-          | Html_block _
-          | Definition_list _
+          | Paragraph _ | Thematic_break _ | Html_block _ | Definition_list _
           | Code_block _ ->
               ())
         blocks
@@ -56,16 +45,14 @@ let rec find_start headers level number subsections =
         match subsections with
         | [] -> headers (* no subsection to find *)
         | n :: subsections -> find_start headers (level + 1) n subsections
-      else
-        find_start tl level number subsections
+      else find_start tl level number subsections
   | (_, header_level, _) :: tl when header_level = level ->
       (* At proper [level].  Have we reached the [number] one? *)
       if number <= 1 then
         match subsections with
         | [] -> tl (* no subsection to find *)
         | n :: subsections -> find_start tl (level + 1) n subsections
-      else
-        find_start tl level (number - 1) subsections
+      else find_start tl level (number - 1) subsections
   | _ ->
       (* Sought [level] has not been found in the current section *)
       []
@@ -74,9 +61,7 @@ let unordered_list items = List ([], Bullet '*', Tight, items)
 
 let find_id attributes =
   List.find_map
-    (function
-      | k, v when String.equal "id" k -> Some v
-      | _ -> None)
+    (function k, v when String.equal "id" k -> Some v | _ -> None)
     attributes
 
 let link attributes label =
@@ -125,6 +110,4 @@ let toc ?(start = []) ?(depth = 2) doc =
   in
   let len = List.length start in
   let toc, _ = make_toc headers ~min_level:(len + 1) ~max_level:(len + depth) in
-  match toc with
-  | [] -> []
-  | _ -> [ unordered_list toc ]
+  match toc with [] -> [] | _ -> [ unordered_list toc ]

--- a/tests/extract_tests.ml
+++ b/tests/extract_tests.ml
@@ -23,9 +23,7 @@ let begins_with s s' =
   String.length s >= String.length s' && String.sub s 0 (String.length s') = s'
 
 let test_delim = "````````````````````````````````"
-
 let tab_re = Str.regexp_string "→"
-
 let insert_tabs s = Str.global_replace tab_re "\t" s
 
 type test =
@@ -64,14 +62,15 @@ let parse_test_spec filename =
                 end
               in
               get_html ()
-            end else begin
+            end
+            else begin
               add_line buf line;
               get_test ()
             end
           in
           go (get_test () :: tests) (succ example)
-        end else
-          go tests example
+        end
+        else go tests example
   in
   go [] 1
 
@@ -116,7 +115,6 @@ let write_dune_file test_specs tests =
     (fun ppf -> List.iter (pp ppf) tests)
 
 let li_begin_re = Str.regexp_string "<li>\n"
-
 let li_end_re = Str.regexp_string "\n</li>"
 
 let normalize_html s =
@@ -147,7 +145,6 @@ let spec =
   ]
 
 let test_specs = ref []
-
 let add_to_list l x = l := x :: !l
 
 let () =

--- a/tests/omd.ml
+++ b/tests/omd.ml
@@ -8,7 +8,6 @@ let protect ~finally f =
       r
 
 let li_begin_re = Str.regexp_string "<li>\n"
-
 let li_end_re = Str.regexp_string "\n</li>"
 
 let normalize_html s =


### PR DESCRIPTION
Removed deprecated options and options for which we had deprecated values. I'm open to other choices options on `.ocamlformat` file