### PR TITLE
add `--version` flag to cli (closes #253)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           ocaml-compiler: 4.12.x
           dune-cache: true
+      - name: Install deps
+        run: opam install . --deps-only
       - name: Opam lint
         run: |
           opam depext opam-dune-lint --install

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,13 @@
 #
 # @file
 
-.PHONY: test build fmt
+.PHONY: test build fmt deps
 
-build:
+build: deps
 	dune build
+
+deps:
+	opam install . --deps-only --yes
 
 test:
 	-dune build @gen --auto-promote

--- a/README.md
+++ b/README.md
@@ -14,8 +14,18 @@ https://github.com/ocaml/omd/issues.
 Dependencies
 ------------
 
-The minimum version of OCaml required is 4.04.2 Omd does not currently have any
-dependencies apart from the standard library.
+The minimum version of OCaml required is 4.04.2. `omd` depends on the standard library
+and the following packages:
+
+```
+dune-build-info
+```
+
+Dependencies can be installed by running:
+
+```sh
+$ opam install . --deps-only
+```
 
 Installation
 ------------
@@ -31,6 +41,7 @@ You can also build it manually from source with:
 ```sh
 $ git clone https://github.com/ocaml/omd.git
 $ cd omd
+$ opam install . --deps-only
 $ make build
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Dependencies can be installed by running:
 
 ```sh
 $ opam install . --deps-only
+# or
+$ make deps
 ```
 
 Installation
@@ -41,7 +43,6 @@ You can also build it manually from source with:
 ```sh
 $ git clone https://github.com/ocaml/omd.git
 $ cd omd
-$ opam install . --deps-only
 $ make build
 ```
 

--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,4 @@
 (executable
  (name main)
  (public_name omd)
- (libraries omd))
+ (libraries omd dune-build-info))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -22,6 +22,15 @@ let process ic oc =
   let md = Omd.of_channel ic in
   output_string oc (Omd.to_html md)
 
+let print_version () =
+  let version =
+    match Build_info.V1.version () with
+    | None -> "n/a"
+    | Some v -> Build_info.V1.Version.to_string v
+  in
+  print_endline version;
+  exit 0
+
 let input = ref []
 
 let output = ref ""
@@ -30,6 +39,9 @@ let spec =
   [ ( "-o"
     , Arg.Set_string output
     , " file.html Specify the output file (default is stdout)." )
+  ; ( "--version"
+    , Arg.Unit print_version
+    , " Display the version of the currently installed omd." )
   ; ( "--"
     , Rest (fun s -> input := s :: !input)
     , " Consider all remaining arguments as input file names." )

--- a/dune-project
+++ b/dune-project
@@ -24,4 +24,5 @@ Additionally, OMD implements a few Github markdown features, an
 extension mechanism, and some other features. Note that the opam
 package installs both the OMD library and the command line tool `omd`.")
  (tags (org:ocamllabs org:mirage))
- (depends (ocaml (>= 4.04))))
+ (depends (ocaml (>= 4.04))
+          (dune-build-info (>= 2.7))))

--- a/omd.opam
+++ b/omd.opam
@@ -23,6 +23,7 @@ bug-reports: "https://github.com/ocaml/omd/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.04"}
+  "dune-build-info" {>= "2.7"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
See https://github.com/ocaml/omd/issues/253.

This (currently draft) PR adds a `--version` flag to the `omd` CLI program. It's using the [`dune-build-info`](https://dune.readthedocs.io/en/latest/dune-libs.html#dune-build-info-library) library to extract the version from `dune-project` to avoid needing another place to track the version.

I'm open to feedback here, because on the one hand this seems convenient (i.e. not having to re-define the version in code since it's already in `dune-project`) but on the other it might be preferable to keep this library dependency-free.

Changes:
- [x] add `--version` flag to CLI
- [x] add `deps` make target so `make build` automatically fetches dependencies
- [x] Update [`README.md`](https://github.com/ocaml/omd#dependencies) which currently states no dependencies
- [x] fix [CI lint error](https://github.com/ocaml/omd/runs/5455295731?check_suite_focus=true) (install dependency in github action)