### PR TITLE
Pin setup-ocaml at v2.0.3

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v2.0.3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 


### PR DESCRIPTION
Seems our window builds on failing on 4.04.2 on the new setup-ocaml release. Seeing if rolling back to the last patch fixes the problem.