### PR TITLE
unicode link label normalization (fix test 539)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -25,4 +25,7 @@ extension mechanism, and some other features. Note that the opam
 package installs both the OMD library and the command line tool `omd`.")
  (tags (org:ocamllabs org:mirage))
  (depends (ocaml (>= 4.05))
+          uutf
+          uucp
+          uunf
           (dune-build-info (>= 2.7))))

--- a/omd.opam
+++ b/omd.opam
@@ -23,6 +23,9 @@ bug-reports: "https://github.com/ocaml/omd/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.05"}
+  "uutf"
+  "uucp"
+  "uunf"
   "dune-build-info" {>= "2.7"}
   "odoc" {with-doc}
 ]

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,7 @@
 (library
  (name omd)
  (public_name omd)
+ (libraries uutf uucp uunf)
  (flags :standard -w -30))
 
 (rule

--- a/tests/blackbox/normalize-label.t
+++ b/tests/blackbox/normalize-label.t
@@ -1,0 +1,31 @@
+Case insensitive comparison
+  $ omd << "MD"
+  > [ΑΓΩ]: /url
+  > 
+  > [αγω]
+  > MD
+  <p><a href="/url">αγω</a></p>
+
+Collapse consecutive internal spaces, tabs
+  $ omd << "MD"
+  > [ΑΓ  	Ω]: /url
+  > 
+  > [αγ ω]
+  > MD
+  <p><a href="/url">αγ ω</a></p>
+
+Strip leading and trailing spaces, tabs
+  $ omd << "MD"
+  > [ 	ΑΓΩ  ]: /url
+  > 
+  > [αγω]
+  > MD
+  <p><a href="/url">αγω</a></p>
+
+Doesn't match due to the internal space
+  $ omd << "MD"
+  > [ΑΓΩ]: /url
+  > 
+  > [α γω]
+  > MD
+  <p>[α γω]</p>

--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -5231,6 +5231,7 @@
   (alias spec-536)
   (alias spec-537)
   (alias spec-538)
+  (alias spec-539)
   (alias spec-540)
   (alias spec-541)
   (alias spec-542)

--- a/tests/extract_tests.ml
+++ b/tests/extract_tests.ml
@@ -8,7 +8,7 @@ let protect ~finally f =
       finally ();
       r
 
-let disabled = [ 206; 215; 216; 519; 539 ]
+let disabled = [ 206; 215; 216; 519 ]
 
 let with_open_in fn f =
   let ic = open_in fn in


### PR DESCRIPTION
Input:

```
[ẞ]

[SS]: /url
```

This is the result in master:

```diff
File "tests/spec-539.html", line 1, characters 0-0:
diff --git a/_build/default/tests/spec-539.html b/_build/default/tests/spec-539.html.new
index c31102f..4e28a6f 100644
--- a/_build/default/tests/spec-539.html
+++ b/_build/default/tests/spec-539.html.new
@@ -1 +1 @@
-<p><a href="/url">ẞ</a></p>
+<p>[ẞ]</p>
make: *** [test] Error 1   
```

The issue is that both labels are not being matched, hence is it not recognized as a link. To match labels, we need to `normalize` them (strip off leading/trailing whitespace, ...) and do a case-insensitive comparison. The unicode version of that is a bit more complex as we need to do a `Unicode case folding`. From the spec:

>  One label [matches](https://spec.commonmark.org/0.30/#matches) another just in case their normalized forms are equal. To normalize a label, strip off the opening and closing brackets, perform the Unicode case fold, strip leading and trailing spaces, tabs, and line endings, and collapse consecutive internal spaces, tabs, and line endings to a single space.

This PR adapts the `normalize` function to work with unicode labels too. Fortunately, I could rely on some libs (`uutf`, `uucp`, and `uunf`) and I even found a [piece of code in the doc](https://erratique.ch/software/uucp/doc/Uucp/Case/index.html#caselesseq) that does almost what's needed.

With that adapted `normalize` function, `ẞ` and `SS` are matched. The result is now a link as expected. 