### PR TITLE
fix test 206

### DIFF
--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1444,8 +1444,7 @@ let link_destination st =
         | Some '&' ->
             entity buf st;
             loop n
-        | Some (' ' | '\t' | '\x00' .. '\x1F' | '\x7F' | '\x80' .. '\x9F')
-        | None ->
+        | Some (' ' | '\t' | '\x00' .. '\x1F' | '\x7F') | None ->
             if n > 0 || Buffer.length buf = 0 then raise Fail;
             Buffer.contents buf
         | Some c ->

--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -4902,6 +4902,7 @@
   (alias spec-203)
   (alias spec-204)
   (alias spec-205)
+  (alias spec-206)
   (alias spec-207)
   (alias spec-208)
   (alias spec-209)

--- a/tests/extract_tests.ml
+++ b/tests/extract_tests.ml
@@ -8,7 +8,7 @@ let protect ~finally f =
       finally ();
       r
 
-let disabled = [ 206; 215; 216; 519 ]
+let disabled = [ 215; 216; 519 ]
 
 let with_open_in fn f =
   let ic = open_in fn in


### PR DESCRIPTION
Input:

```
[ΑΓΩ]: /φου

[αγω]
```

The current result in master:

```diff
File "tests/spec-206.html", line 1, characters 0-0:
diff --git a/_build/default/tests/spec-206.html b/_build/default/tests/spec-206.html.new
index 93c6540..97ea23b 100644
--- a/_build/default/tests/spec-206.html
+++ b/_build/default/tests/spec-206.html.new
@@ -1 +1,2 @@
-<p><a href="/%CF%86%CE%BF%CF%85">αγω</a></p>
+<p>[ΑΓΩ]: /φου</p>
+<p>[αγω]</p>
```

There are two issues here:

1. Labels are not being matched, hence it is not recognized as a link. This is what I fixed in https://github.com/ocaml/omd/pull/277. I included that change in the first commit.

2. The url destination is not percent encoded. From the spec:
  > A [link destination](https://spec.commonmark.org/0.30/#link-destination) consists of either
  > 
  > * a sequence of zero or more characters between an opening < and a closing > that contains no line endings or unescaped < or characters, or
  > 
  > * a nonempty sequence of characters that does not start with <, does not include [ASCII control characters](https://spec.commonmark.org/0.30/#ascii-control-character) or [space](https://spec.commonmark.org/0.30/#space) character, and includes parentheses only if (a) they are backslash-escaped or (b) they are part of a balanced pair of unescaped parentheses. (Implementations may impose limits on parentheses nesting to avoid performance issues, but at least three levels of nesting should be supported.)
  
  And `ASCII control characters are:
  
  > An [ASCII control character](https://spec.commonmark.org/0.30/#ascii-control-character) is a character between U+0000–1F (both including) or U+007F.
  
  I'm not sure why `'\x80' .. '\x9F'` were [being matched](https://github.com/ocaml/omd/compare/fix-206?expand=1#diff-2f56b48efe4c0b849c5b527b223a6c8ab85abd599e10f8b465f5c9801449a468L1311) since, according to the spec, they're not considered as an `ASCII control characters. 
  Removing them from the pattern fixes the test and doesn't break any other so I guess that's fine.


Fix #272 