### PR TITLE
Bump min ocaml version to 4.05

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,7 +16,7 @@ jobs:
         ocaml-compiler:
           # Decision on version matrix informed by https://discuss.ocaml.org/t/which-ocaml-compiler-versions-should-we-run-against-in-ci/7933/2
           - 4.05.0
-          - 4.13.x
+          - 4.14.x
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -42,10 +42,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Use OCaml 4.13.x
+      - name: Use OCaml 4.14.x
         uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: 4.13.x
+          ocaml-compiler: 4.14.x
           dune-cache: true
 
       - name: Lint doc
@@ -57,10 +57,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Use OCaml 4.13.x
+      - name: Use OCaml 4.14.x
         uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: 4.13.x
+          ocaml-compiler: 4.14.x
           dune-cache: true
 
       - name: Lint fmt
@@ -72,10 +72,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Use OCaml 4.13.x
+      - name: Use OCaml 4.14.x
         uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: 4.13.x
+          ocaml-compiler: 4.14.x
           dune-cache: true
 
       - name: Lint opam

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,8 +1,10 @@
 name: Main workflow
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,7 +15,7 @@ jobs:
           - windows-latest
         ocaml-compiler:
           # Decision on version matrix informed by https://discuss.ocaml.org/t/which-ocaml-compiler-versions-should-we-run-against-in-ci/7933/2
-          - 4.04.2
+          - 4.05.0
           - 4.13.x
     runs-on: ${{ matrix.os }}
     steps:

--- a/dune-project
+++ b/dune-project
@@ -24,5 +24,5 @@ Additionally, OMD implements a few Github markdown features, an
 extension mechanism, and some other features. Note that the opam
 package installs both the OMD library and the command line tool `omd`.")
  (tags (org:ocamllabs org:mirage))
- (depends (ocaml (>= 4.04))
+ (depends (ocaml (>= 4.05))
           (dune-build-info (>= 2.7))))

--- a/omd.opam
+++ b/omd.opam
@@ -22,7 +22,7 @@ homepage: "https://github.com/ocaml/omd"
 bug-reports: "https://github.com/ocaml/omd/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.04"}
+  "ocaml" {>= "4.05"}
   "dune-build-info" {>= "2.7"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Addresses https://github.com/ocaml/camlp-streams/issues/7 breaking our CI pipeline by bumping the minimum required OCaml version to 4.05.

Also see https://github.com/ocaml/omd/pull/275#issuecomment-1201523735