### PR TITLE
Suggestion to simplify add_uchar

### DIFF
--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1119,16 +1119,16 @@ let normalize s =
           add_nfd (`Uchar Uutf.u_rep);
           false
       | `Uchar u as uchar ->
-          if Uucp.White.is_white_space u then
-            (if not seen_ws then add_nfd uspace; true)
+          if Uucp.White.is_white_space u then (
+            if not seen_ws then add_nfd uspace;
+            true)
           else (
             add_nfd uchar;
-            seen_ws
-          )
+            seen_ws)
     in
     (* flag used to eliminate repeated white space *)
     let seen_ws = false in
-    ignore(Uutf.String.fold_utf_8 add_uchar seen_ws s);
+    ignore (Uutf.String.fold_utf_8 add_uchar seen_ws s);
     add_nfd `End;
     to_nfd_and_utf_8 `End;
     Buffer.contents b


### PR DESCRIPTION
Hi, @tatchi. What do you think of this suggestion for the `add_uchar` function? The tests seem to be passing, and I *think* the logic follows, tho you've thought more about this than I have and I'm not sure if I may be missing an edge case.

I think we can do away with the flag to track `start` by ensuring that we add the space uchar when we first detect white space, then use the `seen_ws` to ensure we don't add repeated whitespace.

WDYT?

This PR targets your PR #277, so if you like the suggestion you can merge it in.