### PR TITLE
fix 215 and 216

### DIFF
--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -4911,6 +4911,8 @@
   (alias spec-212)
   (alias spec-213)
   (alias spec-214)
+  (alias spec-215)
+  (alias spec-216)
   (alias spec-217)
   (alias spec-218)
   (alias spec-219)

--- a/tests/extract_tests.ml
+++ b/tests/extract_tests.ml
@@ -8,7 +8,7 @@ let protect ~finally f =
       finally ();
       r
 
-let disabled = [ 215; 216; 519 ]
+let disabled = [ 519 ]
 
 let with_open_in fn f =
   let ic = open_in fn in


### PR DESCRIPTION
### Test 215

```md
[foo]: /url
bar
===
[foo]
```

Current result:

```
<h1>[foo]: /url                     
bar</h1>
<p>[foo]</p>
```

Expected result:

```
<h1>bar</h1>
<p><a href="/url">foo</a></p>
```

The issue is that when parsing a `Lsetext_heading` (===), we were wrapping all the `Rparagraph` lines in a `Heading`, without taking into account that some of the `lines` might be a `link reference definition`

### Test 216

```
[foo]: /url
===
[foo]
```

Current result:

```
<h1>[foo]: /url</h1>                
<p>[foo]</p>
```

Expected result:

```
<p>===
<a href="/url">foo</a></p>
```

Same as 216 except that in that case there's nothing between the `link reference definition` and the `Lsetext_heading`. There's nothing then to make as `Heading`.