### PR TITLE
Rework element constructors

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2.0.3
+        uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 

--- a/dune-project
+++ b/dune-project
@@ -24,9 +24,11 @@ Additionally, OMD implements a few Github markdown features, an
 extension mechanism, and some other features. Note that the opam
 package installs both the OMD library and the command line tool `omd`.")
  (tags (org:ocamllabs org:mirage))
- (depends (ocaml (>= 4.08))
-          stdcompat
-          uutf
-          uucp
-          uunf
-          (dune-build-info (>= 2.7))))
+ (depends
+  (ocaml (>= 4.08))
+   stdcompat
+   uutf
+   uucp
+   uunf
+  (dune-build-info (>= 2.7))
+  (ppx_expect :with-test)))

--- a/omd.opam
+++ b/omd.opam
@@ -28,6 +28,7 @@ depends: [
   "uucp"
   "uunf"
   "dune-build-info" {>= "2.7"}
+  "ppx_expect" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/src/ast_constructors.ml
+++ b/src/ast_constructors.ml
@@ -1,0 +1,219 @@
+open Ast.Impl
+
+module type Intf = sig
+  (** Functions to help constructing the elements of a {!doc}.
+
+      E.g.,
+
+      {[
+        let open Omd.Ctor in
+        let para =
+          p ~attrs:[ ("class", "my-para") ] [ txt "Content of"; em "this"; txt "paragraph" ]
+        in
+        [ blockquote [ para; hr; p [ txt "Content of second paragraph" ] ] ]
+      ]}
+
+      Produces
+
+      {v
+<blockquote>
+<p class="my-para">Content of<em>this</em>paragraph</p>
+<hr />
+<p>Content of second paragraph</p>
+</blockquote>
+      v}
+
+      The optional [attrs] argument always defaults to an empty list, and can
+      generally be omitted. *)
+
+  (** {3 Constructors for inline elements}  *)
+
+  val txt : ?attrs:attributes -> string -> attributes inline
+  (** [txt ~attrs s] is {{!Text} [Text (attrs, s)]}. *)
+
+  val em : ?attrs:attributes -> string -> attributes inline
+  (** [em ~attrs s] is {{!Emph} [Emph (attrs, txt s)]}. See {!txt}. *)
+
+  val strong : ?attrs:attributes -> string -> attributes inline
+  (** [strong ~attrs s] is {{!Strong} [Strong (attrs, txt s)]}. See {!txt}. *)
+
+  val code : ?attrs:attributes -> string -> attributes inline
+  (** [code ~attrs s] is {{!Code} [Code (attrs, s)]}. *)
+
+  val br : attributes inline
+  (** [br] is {{!Hard_break}[Hard_break []]}. *)
+
+  val nl : attributes inline
+  (** [nl] is {{!Soft_break}[Soft_break []]}. *)
+
+  val a :
+       ?attrs:attributes
+    -> ?title:string
+    -> url:string
+    -> string
+    -> attributes inline
+  (** [a ~attrs ~title ~url label] is a link around the text of [label],
+      pointing to the [url], with the optional title [title] and additional [attrs].
+      See {!Link}. *)
+
+  val img :
+       ?attrs:attributes
+    -> ?title:string
+    -> alt:string
+    -> string
+    -> attributes inline
+  (** [img ~attrs ~title ~alt src] is an image from the given [src] that has the
+      [alt] text as a fallback, with the optional title [title] and additional
+      [attrs].  See {!Image}. *)
+
+  val html : string -> attributes inline
+  (** [html s] is an inline HTML string. See {!Html}. *)
+
+  (** {3 Constructors for block-level elements} *)
+
+  val p : ?attrs:attributes -> attributes inline list -> attributes block
+  (** [p ~attrs inlines] is a pragraph block holding the given [inline]
+      elements. See {!Paragraph}. *)
+
+  val ul :
+       ?attrs:attributes
+    -> ?spacing:list_spacing
+    -> attributes block list list
+    -> attributes block
+  (** [ul ~attrs ~spacing items] is an unordered list with the specified [spacing], listing
+      the given [items]. Each item is a list of block elements.
+
+      - [spacing] defaults to {!Loose}.
+
+      E.g.,
+
+      {[
+        ul ~spacing:Tight
+          [ [ p [ txt "Item 1" ] ]
+          ; [ p [ txt "Item 2" ] ]
+          ; [ p [ txt "Item 3" ] ]
+          ]
+      ]}
+
+      See {!List} and {!Bullet}. *)
+
+  val ol :
+       ?attrs:attributes
+    -> ?start:int
+    -> ?char:[ `Dot | `Paren ]
+    -> ?spacing:list_spacing
+    -> attributes block list list
+    -> attributes block
+  (** [ol ~attrs ~start ~char ~spacing items] is like {!ul}, but constructs an ordered list,
+      where [start] is the number to start enumerating from, and [char] indicates the
+      character following the number in the enumeration.
+
+      - [char] can be either [`Dot] indicating ['.'] or [`Paren] indicating [')'], and
+        defaults to [`Dot].
+      - [start] defaults to [1].
+
+      See {!List} and {!Ordered}. *)
+
+  val blockquote :
+    ?attrs:attributes -> attributes block list -> attributes block
+  (** [blockquote ~attrs blocks] is a blockquote element containing the given
+      [blocks]. See {!Blockquote}. *)
+
+  val hr : attributes block
+  (** [hr] is {{!Thematic_break} [Thematic_break []]}. *)
+
+  val h : ?attrs:attributes -> int -> attributes inline list -> attributes block
+  (** [h ~attrs level inlines] is a heading of the given [level] comprised of
+      the [inlines]. See {!Heading}. *)
+
+  val code_bl : ?attrs:attributes -> ?lang:string -> string -> attributes block
+  (** [code_bl ~attrs ~lang code] is a code block labeled with language [lang].
+
+      - [lang] defaults to being absent.
+
+      See {!Code_block} *)
+
+  val html_bl : ?attrs:attributes -> string -> attributes block
+  (** [html_bl ~attrs html] is a block-level element of raw HTML. See {!Html_block}. *)
+
+  type 'attr ctor_def_elt =
+    { term : 'attr inline list
+    ; defs : 'attr inline list list
+    }
+  (** Type for the items given to {!dl} definition lists. It is isomorphic to {!def_elt}. *)
+
+  val dl : ?attrs:attributes -> attributes ctor_def_elt list -> attributes block
+  (** [dl ~attrs elements] is a definition list of the given [elements]. See
+      {!Definition_list}.
+
+      E.g.,
+
+      {[
+        dl
+          [ { term = [ txt "def term 1" ]
+            ; defs =
+                [ [ txt "definition 1.1" ]
+                ; [ txt "definition 1.2" ]
+                ; [ txt "definition 1.3" ]
+                ]
+            }
+          ; { term = [ txt "def term 2" ]
+            ; defs =
+                [ [ txt "definition 2.1" ]
+                ; [ txt "definition 2.2" ]
+                ; [ txt "definition 2.3" ]
+                ]
+            }
+          ]
+      ]} *)
+end
+
+module Impl : Intf = struct
+  let concat elems = Concat ([], elems)
+  let txt ?(attrs = []) s = Text (attrs, s)
+  let em ?(attrs = []) s = Emph (attrs, txt s)
+  let strong ?(attrs = []) s = Strong (attrs, txt s)
+  let code ?(attrs = []) s = Code (attrs, s)
+  let br = Hard_break []
+  let nl = Soft_break []
+
+  let a ?(attrs = []) ?title ~url label =
+    Link (attrs, { label = txt label; destination = url; title })
+
+  let img ?(attrs = []) ?title ~alt src =
+    Image (attrs, { label = txt alt; destination = src; title })
+
+  (* Note that attributes are not actually supported Html nodes currently. *)
+  let html s = Html ([], s)
+
+  (* Block constructors *)
+
+  let p ?(attrs = []) inlines = Paragraph (attrs, concat inlines)
+
+  let ul ?(attrs = []) ?(spacing = Loose) items =
+    List (attrs, Bullet '-', spacing, items)
+
+  let ol ?(attrs = []) ?(start = 1) ?(char = `Dot) ?(spacing = Loose) items =
+    let c = match char with `Dot -> '.' | `Paren -> ')' in
+    List (attrs, Ordered (start, c), spacing, items)
+
+  let blockquote ?(attrs = []) blocks = Blockquote (attrs, blocks)
+  let hr = Thematic_break []
+  let h ?(attrs = []) level inlines = Heading (attrs, level, concat inlines)
+  let code_bl ?(attrs = []) ?(lang = "") s = Code_block (attrs, lang, s)
+  let html_bl ?(attrs = []) s = Html_block (attrs, s)
+
+  type 'attr ctor_def_elt =
+    { term : 'attr inline list
+    ; defs : 'attr inline list list
+    }
+
+  let dl ?(attrs = []) (items : 'attr ctor_def_elt list) =
+    let def_elt_of_pair { term; defs } : 'attr def_elt =
+      let term = concat term in
+      let defs = List.map concat defs in
+      { term; defs }
+    in
+    let def_elts = List.map def_elt_of_pair items in
+    Definition_list (attrs, def_elts)
+end

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -1,4 +1,10 @@
+(* The document model *)
+
 include Ast.Impl
+
+(* Helper functions for construction document AST *)
+
+module Ctor = Ast_constructors.Impl
 
 (* Table of contents *)
 

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -6,6 +6,10 @@
 
 include Ast.Intf
 
+(** {2 Helper functions for constructing the document AST } *)
+
+module Ctor : Ast_constructors.Intf
+
 (** {2 Generating and constructing tables of contents} *)
 
 val headers :

--- a/tests/dune
+++ b/tests/dune
@@ -1,3 +1,11 @@
+(library
+ (name expect_tests)
+ (modules expect_tests)
+ (inline_tests)
+ (preprocess
+  (pps ppx_expect))
+ (libraries omd))
+
 (executable
  (name extract_tests)
  (libraries str)

--- a/tests/expect_tests.ml
+++ b/tests/expect_tests.ml
@@ -1,0 +1,149 @@
+let show x = Omd.to_html x |> print_string
+
+let%expect_test "construct inline elements" =
+  show
+    Omd.Ctor.
+      [ p
+          [ em "emphasized"
+          ; br
+          ; strong ~attrs:[ ("class", "my-class") ] "strong"
+          ; nl
+          ; code "some code"
+          ; nl
+          ; a "label" ~url:"my/page/url"
+          ; nl
+          ; a "other label" ~url:"my/other/page" ~title:"title text"
+          ; nl
+          ; img "my/img/src" ~alt:"Some alt text"
+          ; nl
+          ; img "my/img/src" ~alt:"Some alt text" ~title:"some title"
+          ; nl
+          ; html "<em>inline html <!-- with a comment! --> here</em>"
+          ]
+      ];
+  [%expect
+    {|
+    <p><em>emphasized</em><br />
+    <strong class="my-class">strong</strong>
+    <code>some code</code>
+    <a href="my/page/url">label</a>
+    <a href="my/other/page" title="title text">other label</a>
+    <img src="my/img/src" alt="Some alt text" />
+    <img src="my/img/src" alt="Some alt text" title="some title" />
+    <em>inline html <!-- with a comment! --> here</em></p> |}]
+
+let%expect_test "construct headings" =
+  show Omd.Ctor.[ h 1 ~attrs:[ ("class", "my-class") ] [ txt "Heading 1" ] ];
+  [%expect {| <h1 class="my-class">Heading 1</h1> |}];
+  show Omd.Ctor.[ h 6 [ txt "Heading 6"; em "with emphasis!" ] ];
+  [%expect {| <h6>Heading 6<em>with emphasis!</em></h6> |}]
+
+let%expect_test "construct lists" =
+  show
+    Omd.Ctor.
+      [ ul
+          ~spacing:Tight
+          [ [ p [ txt "Item 1" ] ]
+          ; [ p [ txt "Item 2" ] ]
+          ; [ p [ txt "Item 3"; strong "with strength!" ] ]
+          ]
+      ];
+  [%expect
+    {|
+    <ul>
+    <li>Item 1
+    </li>
+    <li>Item 2
+    </li>
+    <li>Item 3<strong>with strength!</strong>
+    </li>
+    </ul> |}];
+  show
+    Omd.Ctor.
+      [ ol
+          [ [ p [ txt "Item 1" ] ]
+          ; [ p [ txt "Item 2" ] ]
+          ; [ p [ txt "Item 3" ] ]
+          ]
+      ];
+  [%expect
+    {|
+    <ol>
+    <li>
+    <p>Item 1</p>
+    </li>
+    <li>
+    <p>Item 2</p>
+    </li>
+    <li>
+    <p>Item 3</p>
+    </li>
+    </ol> |}]
+
+let%expect_test "construct paragraphs and blockquotes with hrs" =
+  let para =
+    Omd.Ctor.(
+      p
+        ~attrs:[ ("class", "my-para") ]
+        [ txt "Contet of"; em "this"; txt "paragraph" ])
+  in
+  show
+    Omd.Ctor.
+      [ blockquote [ para; hr; p [ txt "Content of second paragraph" ] ] ];
+  [%expect
+    {|
+    <blockquote>
+    <p class="my-para">Contet of<em>this</em>paragraph</p>
+    <hr />
+    <p>Content of second paragraph</p>
+    </blockquote> |}]
+
+let%expect_test "construct code blocks" =
+  show
+    Omd.Ctor.
+      [ code_bl
+          ~attrs:[ ("class", "my-code") ]
+          ~lang:"ocaml"
+          "let foo = bar + bing"
+      ];
+  [%expect
+    {| <pre class="my-code"><code class="language-ocaml">let foo = bar + bing</code></pre> |}]
+
+let%expect_test "construct html blocks" =
+  show
+    Omd.Ctor.
+      [ html_bl "<p><em>Some</em> inline HTML <!-- With a comment --> here</p>"
+      ];
+  [%expect {| <p><em>Some</em> inline HTML <!-- With a comment --> here</p> |}]
+
+let%expect_test "construct definition list" =
+  show
+    Omd.Ctor.
+      [ dl
+          [ { term = [ txt "def term 1" ]
+            ; defs =
+                [ [ txt "definition 1.1" ]
+                ; [ txt "definition 1.2" ]
+                ; [ txt "definition 1.3" ]
+                ]
+            }
+          ; { term = [ txt "def term 2" ]
+            ; defs =
+                [ [ txt "definition 2.1" ]
+                ; [ txt "definition 2.2" ]
+                ; [ txt "definition 2.3" ]
+                ]
+            }
+          ]
+      ];
+  [%expect
+    {|
+    <dl><dt>def term 1</dt>
+    <dd>definition 1.1</dd>
+    <dd>definition 1.2</dd>
+    <dd>definition 1.3</dd>
+    <dt>def term 2</dt>
+    <dd>definition 2.1</dd>
+    <dd>definition 2.2</dd>
+    <dd>definition 2.3</dd>
+    </dl> |}]


### PR DESCRIPTION
Followup to #268.

These changes expand and rework the constructors for AST values proposed 
in #252. The aim is to make construction of AST values relatively simple
and light weight.

The constructors lacked some ergonomic convenience, and we were missing
a constructor for headings and missing a way to construct elements that
included concatenated inlines (so, e.g., there was no way of constructing
a paragraph that would include mixing plain text with `em` or `strong` text.

I think this was mostly due to us having omitted  tests that
would show how the constructors were meant to be used when we first
introduced them, so I'm adding in tests as I go so we can see how usage
will look, and spot any irregularities or oversights.