### PR TITLE
Restructure Ast module

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -1,100 +1,19 @@
-type attributes = (string * string) list
+module Impl = struct
+  include Ast_inline
+  include Ast_block.List_types
+  include Ast_block.WithInline
 
-type list_type =
-  | Ordered of int * char
-  | Bullet of char
-
-type list_spacing =
-  | Loose
-  | Tight
-
-type 'attr link_def =
-  { label : string
-  ; destination : string
-  ; title : string option
-  ; attributes : 'attr
-  }
-
-module type T = sig
-  type 'a t
+  type attributes = (string * string) list
+  type doc = attributes block list
 end
 
-module MakeBlock (I : T) = struct
-  type 'attr def_elt =
-    { term : 'attr I.t
-    ; defs : 'attr I.t list
-    }
+module type Intf = module type of Impl
 
-  (* A value of type 'attr is present in all variants of this type. We use it to associate
-     extra information to each node in the AST. In the common case, the attributes type defined
-     above is used. We might eventually have an alternative function to parse blocks while keeping
-     concrete information such as source location and we'll use it for that as well. *)
-  type 'attr block =
-    | Paragraph of 'attr * 'attr I.t
-    | List of 'attr * list_type * list_spacing * 'attr block list list
-    | Blockquote of 'attr * 'attr block list
-    | Thematic_break of 'attr
-    | Heading of 'attr * int * 'attr I.t
-    | Code_block of 'attr * string * string
-    | Html_block of 'attr * string
-    | Definition_list of 'attr * 'attr def_elt list
+module Util = struct
+  include Impl
+
+  let same_block_list_kind k1 k2 =
+    match (k1, k2) with
+    | Ordered (_, c1), Ordered (_, c2) | Bullet c1, Bullet c2 -> c1 = c2
+    | _ -> false
 end
-
-type 'attr link =
-  { label : 'attr inline
-  ; destination : string
-  ; title : string option
-  }
-
-(* See comment on the block type above about the 'attr parameter *)
-and 'attr inline =
-  | Concat of 'attr * 'attr inline list
-  | Text of 'attr * string
-  | Emph of 'attr * 'attr inline
-  | Strong of 'attr * 'attr inline
-  | Code of 'attr * string
-  | Hard_break of 'attr
-  | Soft_break of 'attr
-  | Link of 'attr * 'attr link
-  | Image of 'attr * 'attr link
-  | Html of 'attr * string
-
-module StringT = struct
-  type 'attr t = string
-end
-
-module InlineT = struct
-  type 'attr t = 'attr inline
-end
-
-module Raw = MakeBlock (StringT)
-module Inline = MakeBlock (InlineT)
-include Inline
-
-module MakeMapper (Src : T) (Dst : T) = struct
-  module SrcBlock = MakeBlock (Src)
-  module DstBlock = MakeBlock (Dst)
-
-  let rec map (f : 'attr Src.t -> 'attr Dst.t) :
-      'attr SrcBlock.block -> 'attr DstBlock.block = function
-    | SrcBlock.Paragraph (attr, x) -> DstBlock.Paragraph (attr, f x)
-    | List (attr, ty, sp, bl) ->
-        List (attr, ty, sp, List.map (List.map (map f)) bl)
-    | Blockquote (attr, xs) -> Blockquote (attr, List.map (map f) xs)
-    | Thematic_break attr -> Thematic_break attr
-    | Heading (attr, level, text) -> Heading (attr, level, f text)
-    | Definition_list (attr, l) ->
-        let f { SrcBlock.term; defs } =
-          { DstBlock.term = f term; defs = List.map f defs }
-        in
-        Definition_list (attr, List.map f l)
-    | Code_block (attr, label, code) -> Code_block (attr, label, code)
-    | Html_block (attr, x) -> Html_block (attr, x)
-end
-
-module Mapper = MakeMapper (StringT) (InlineT)
-
-let same_block_list_kind k1 k2 =
-  match (k1, k2) with
-  | Ordered (_, c1), Ordered (_, c2) | Bullet c1, Bullet c2 -> c1 = c2
-  | _ -> false

--- a/src/ast_block.ml
+++ b/src/ast_block.ml
@@ -1,0 +1,69 @@
+module type BlockContent = sig
+  type 'a t
+end
+
+module StringContent = struct
+  type 'attr t = string
+end
+
+module InlineContent = struct
+  type 'attr t = 'attr Ast_inline.inline
+end
+
+module List_types = struct
+  type list_type =
+    | Ordered of int * char
+    | Bullet of char
+
+  type list_spacing =
+    | Loose
+    | Tight
+end
+
+open List_types
+
+module Make (C : BlockContent) = struct
+  type 'attr def_elt =
+    { term : 'attr C.t
+    ; defs : 'attr C.t list
+    }
+
+  (* A value of type 'attr is present in all variants of this type. We use it to associate
+     extra information to each node in the AST. Cn the common case, the attributes type defined
+     above is used. We might eventually have an alternative function to parse blocks while keeping
+     concrete information such as source location and we'll use it for that as well. *)
+  type 'attr block =
+    | Paragraph of 'attr * 'attr C.t
+    | List of 'attr * list_type * list_spacing * 'attr block list list
+    | Blockquote of 'attr * 'attr block list
+    | Thematic_break of 'attr
+    | Heading of 'attr * int * 'attr C.t
+    | Code_block of 'attr * string * string
+    | Html_block of 'attr * string
+    | Definition_list of 'attr * 'attr def_elt list
+end
+
+module MakeMapper (Src : BlockContent) (Dst : BlockContent) = struct
+  module SrcBlock = Make (Src)
+  module DstBlock = Make (Dst)
+
+  let rec map (f : 'attr Src.t -> 'attr Dst.t) :
+      'attr SrcBlock.block -> 'attr DstBlock.block = function
+    | SrcBlock.Paragraph (attr, x) -> DstBlock.Paragraph (attr, f x)
+    | List (attr, ty, sp, bl) ->
+        List (attr, ty, sp, List.map (List.map (map f)) bl)
+    | Blockquote (attr, xs) -> Blockquote (attr, List.map (map f) xs)
+    | Thematic_break attr -> Thematic_break attr
+    | Heading (attr, level, text) -> Heading (attr, level, f text)
+    | Definition_list (attr, l) ->
+        let f { SrcBlock.term; defs } =
+          { DstBlock.term = f term; defs = List.map f defs }
+        in
+        Definition_list (attr, List.map f l)
+    | Code_block (attr, label, code) -> Code_block (attr, label, code)
+    | Html_block (attr, x) -> Html_block (attr, x)
+end
+
+module Mapper = MakeMapper (StringContent) (InlineContent)
+module Raw = Make (StringContent)
+module WithInline = Make (InlineContent)

--- a/src/ast_inline.ml
+++ b/src/ast_inline.ml
@@ -1,0 +1,24 @@
+(* TODO The presence of `attrs` in several of these nodes is leaking an
+        implementation detail: we have no support for attributes in `Concat`
+        `Soft_break` or `Html` nodes. The attributes are just dropped during
+        rendering.  Should we remove this from the UI, or should we include
+        those somehow? Or should we include these in the document model, but
+        but with the caveat that most renderings of the document don't support
+        attributes in these nodes? *)
+type 'attr inline =
+  | Concat of 'attr * 'attr inline list
+  | Text of 'attr * string
+  | Emph of 'attr * 'attr inline
+  | Strong of 'attr * 'attr inline
+  | Code of 'attr * string
+  | Hard_break of 'attr
+  | Soft_break of 'attr
+  | Link of 'attr * 'attr link
+  | Image of 'attr * 'attr link
+  | Html of 'attr * string
+
+and 'attr link =
+  { label : 'attr inline
+  ; destination : string
+  ; title : string option
+  }

--- a/src/block.mli
+++ b/src/block.mli
@@ -1,8 +1,0 @@
-open Ast
-
-module Pre : sig
-  val of_channel :
-    in_channel -> attributes Raw.block list * attributes link_def list
-
-  val of_string : string -> attributes Raw.block list * attributes link_def list
-end

--- a/src/block_parser.ml
+++ b/src/block_parser.ml
@@ -1,4 +1,5 @@
-open Ast
+open Ast.Util
+module Raw = Ast_block.Raw
 
 module Pre = struct
   type container =

--- a/src/block_parser.mli
+++ b/src/block_parser.mli
@@ -1,0 +1,10 @@
+open Ast.Impl
+module Raw = Ast_block.Raw
+
+module Pre : sig
+  val of_channel :
+    in_channel -> attributes Raw.block list * attributes Parser.link_def list
+
+  val of_string :
+    string -> attributes Raw.block list * attributes Parser.link_def list
+end

--- a/src/html.ml
+++ b/src/html.ml
@@ -1,4 +1,4 @@
-open Ast
+open Ast.Impl
 
 type element_type =
   | Inline
@@ -115,7 +115,7 @@ and img label destination title attrs =
   elt Inline "img" attrs None
 
 and inline = function
-  | Ast.Concat (_, l) -> concat_map inline l
+  | Ast.Impl.Concat (_, l) -> concat_map inline l
   | Text (_, t) -> text t
   | Emph (attr, il) -> elt Inline "em" attr (Some (inline il))
   | Strong (attr, il) -> elt Inline "strong" attr (Some (inline il))

--- a/src/html.mli
+++ b/src/html.mli
@@ -1,4 +1,4 @@
-open Ast
+open Ast.Impl
 
 type element_type =
   | Inline

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -1,42 +1,24 @@
-module Pre = Block.Pre
-include Ast
+include Ast.Impl
 
-type doc = attributes block list
+(* Table of contents *)
+
+let headers = Toc.headers
+let toc = Toc.toc
+
+(* Conversion *)
 
 let parse_inline defs s = Parser.inline defs (Parser.P.of_string s)
 
-let parse_inlines (md, defs) =
+let parse_inlines (md, defs) : doc =
   let defs =
-    let f (def : attributes link_def) =
+    let f (def : attributes Parser.link_def) =
       { def with label = Parser.normalize def.label }
     in
     List.map f defs
   in
-  List.map (Mapper.map (parse_inline defs)) md
+  List.map (Ast_block.Mapper.map (parse_inline defs)) md
 
-let txt ?(attrs = []) s = Text (attrs, s)
-let em ?(attrs = []) il = Emph (attrs, il)
-let strong ?(attrs = []) il = Strong (attrs, il)
-let code ?(attrs = []) s = Code (attrs, s)
-let br = Hard_break []
-let nl = Soft_break []
-let a ?(attrs = []) li = Link (attrs, li)
-let img ?(attrs = []) li = Image (attrs, li)
-let html ?(attrs = []) s = Html (attrs, s)
-let p ?(attrs = []) il = Paragraph (attrs, il)
-let ul ?(attrs = []) ?(spacing = Loose) l = List (attrs, Bullet '-', spacing, l)
-
-let ol ?(attrs = []) ?(spacing = Loose) l =
-  List (attrs, Ordered (1, '.'), spacing, l)
-
-let blockquote ?(attrs = []) blocks = Blockquote (attrs, blocks)
-let hr = Thematic_break []
-let code_bl ?(attrs = []) ~label s = Code_block (attrs, label, s)
-let html_bl ?(attrs = []) s = Html_block (attrs, s)
-let dl ?(attrs = []) l = Definition_list (attrs, l)
-let of_channel ic = parse_inlines (Pre.of_channel ic)
-let of_string s = parse_inlines (Pre.of_string s)
-let to_html doc = Html.to_string (Html.of_doc doc)
+let of_channel ic : doc = parse_inlines (Block_parser.Pre.of_channel ic)
+let of_string s = parse_inlines (Block_parser.Pre.of_string s)
+let to_html (doc : doc) = Html.to_string (Html.of_doc doc)
 let to_sexp ast = Format.asprintf "@[%a@]@." Sexp.print (Sexp.create ast)
-let headers = Toc.headers
-let toc = Toc.toc

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -1,85 +1,21 @@
-(** A markdown parser in OCaml. *)
+(** {1 A markdown parser in OCaml} *)
 
-type attributes = (string * string) list
+(** {2 The document model}
 
-type list_type =
-  | Ordered of int * char
-  | Bullet of char
+    The following types define the AST representing Omd's document model. *)
 
-type list_spacing =
-  | Loose
-  | Tight
+include Ast.Intf
 
-type 'attr link =
-  { label : 'attr inline
-  ; destination : string
-  ; title : string option
-  }
-
-and 'attr inline =
-  | Concat of 'attr * 'attr inline list
-  | Text of 'attr * string
-  | Emph of 'attr * 'attr inline
-  | Strong of 'attr * 'attr inline
-  | Code of 'attr * string
-  | Hard_break of 'attr
-  | Soft_break of 'attr
-  | Link of 'attr * 'attr link
-  | Image of 'attr * 'attr link
-  | Html of 'attr * string
-
-type 'attr def_elt =
-  { term : 'attr inline
-  ; defs : 'attr inline list
-  }
-
-type 'attr block =
-  | Paragraph of 'attr * 'attr inline
-  | List of 'attr * list_type * list_spacing * 'attr block list list
-  | Blockquote of 'attr * 'attr block list
-  | Thematic_break of 'attr
-  | Heading of 'attr * int * 'attr inline
-  | Code_block of 'attr * string * string
-  | Html_block of 'attr * string
-  | Definition_list of 'attr * 'attr def_elt list
-
-type doc = attributes block list
-(** A markdown document *)
-
-val txt : ?attrs:attributes -> string -> attributes inline
-val em : ?attrs:attributes -> attributes inline -> attributes inline
-val strong : ?attrs:attributes -> attributes inline -> attributes inline
-val code : ?attrs:attributes -> string -> attributes inline
-val br : attributes inline
-val nl : attributes inline
-val a : ?attrs:attributes -> attributes link -> attributes inline
-val img : ?attrs:attributes -> attributes link -> attributes inline
-val html : ?attrs:attributes -> string -> attributes inline
-val p : ?attrs:attributes -> attributes inline -> attributes block
-
-val ul :
-     ?attrs:attributes
-  -> ?spacing:list_spacing
-  -> attributes block list list
-  -> attributes block
-
-val ol :
-     ?attrs:attributes
-  -> ?spacing:list_spacing
-  -> attributes block list list
-  -> attributes block
-
-val blockquote : ?attrs:attributes -> attributes block list -> attributes block
-val hr : attributes block
-val code_bl : ?attrs:attributes -> label:string -> string -> attributes block
-val html_bl : ?attrs:attributes -> string -> attributes block
-val dl : ?attrs:attributes -> attributes def_elt list -> attributes block
-val of_channel : in_channel -> doc
-val of_string : string -> doc
-val to_html : doc -> string
-val to_sexp : doc -> string
+(** {2 Generating and constructing tables of contents} *)
 
 val headers :
   ?remove_links:bool -> 'attr block list -> ('attr * int * 'attr inline) list
 
 val toc : ?start:int list -> ?depth:int -> doc -> doc
+
+(** {2 Converting to and from documents} *)
+
+val of_channel : in_channel -> doc
+val of_string : string -> doc
+val to_html : doc -> string
+val to_sexp : doc -> string

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1,5 +1,12 @@
-open Ast
+open Ast.Impl
 open Stdcompat
+
+type 'attr link_def =
+  { label : string
+  ; destination : string
+  ; title : string option
+  ; attributes : 'attr
+  }
 
 let is_whitespace = function
   | ' ' | '\t' | '\010' .. '\013' -> true
@@ -1566,7 +1573,7 @@ let autolink st =
       junk st;
       let label, destination = (absolute_uri ||| email_address) st in
       if next st <> '>' then raise Fail;
-      { Ast.label = Text ([], label); destination; title = None }
+      { Ast.Impl.label = Text ([], label); destination; title = None }
   | _ -> raise Fail
 
 let inline_link =
@@ -1873,7 +1880,7 @@ let sp3 st =
   | _ -> 0
   | exception Fail -> 0
 
-let link_reference_definition st : attributes Ast.link_def =
+let link_reference_definition st : attributes link_def =
   (* TODO remove duplicated ws/ws1 functions? *)
   let ws st =
     let rec loop seen_nl =

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -1,4 +1,4 @@
-open Ast
+open Ast.Impl
 
 type t =
   | Atom of string

--- a/src/toc.ml
+++ b/src/toc.ml
@@ -1,4 +1,4 @@
-open Ast
+open Ast.Util
 open Stdcompat
 
 let rec remove_links inline =


### PR DESCRIPTION
This aims to improve the organization of the Ast module. The key changes:

- Avoid duplication of types by use of `module include type of`
- Break up Inline types and Block types into seperate modules
- Improve naming on block type funtors
- Correct name of `Block` module to `Block_parser`, cause it's a parser,
  not a representation of blocks

This was spun out of work on #288 and is a pre-requisite for the changes there, as it allows sharing the high-level `doc` type.