### PR TITLE
Expose HTML escape function

### DIFF
--- a/src/html.mli
+++ b/src/html.mli
@@ -11,5 +11,6 @@ type t =
   | Null
   | Concat of t * t
 
+val htmlentities : string -> string
 val of_doc : attributes block list -> t
 val to_string : t -> string

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -18,6 +18,7 @@ let parse_inlines (md, defs) : doc =
   in
   List.map (Ast_block.Mapper.map (parse_inline defs)) md
 
+let escape_html_entities = Html.htmlentities
 let of_channel ic : doc = parse_inlines (Block_parser.Pre.of_channel ic)
 let of_string s = parse_inlines (Block_parser.Pre.of_string s)
 let to_html (doc : doc) = Html.to_string (Html.of_doc doc)

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -13,6 +13,13 @@ val headers :
 
 val toc : ?start:int list -> ?depth:int -> doc -> doc
 
+(** {2 Helper functions} *)
+
+val escape_html_entities : string -> string
+(** Perform escaping of HTML entities. Turns: ['"'] into ["&quot;"],
+    ['&'] into ["&amp;"], ['<'] in ["&lt;"] and ['>'] into ["&gt;"]
+*)
+
 (** {2 Converting to and from documents} *)
 
 val of_channel : in_channel -> doc


### PR DESCRIPTION
Expose escape_html_entities which escapes meaningful HTML characters
in order to prevent them from being interpreted.

This is needed by Hilite. See issue
https://github.com/ocaml/ocaml.org/issues/496
