### PR TITLE
Expose Html.to_plain_text as Omd.to_string

### DIFF
--- a/src/html.mli
+++ b/src/html.mli
@@ -13,5 +13,6 @@ type t =
   | Concat of t * t
 
 val htmlentities : string -> string
+val to_plain_text : 'a Ast.Impl.inline -> string
 val of_doc : ?auto_identifiers:bool -> attributes block list -> t
 val to_string : t -> string

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -32,3 +32,5 @@ let to_html ?auto_identifiers doc =
   Html.to_string (Html.of_doc ?auto_identifiers doc)
 
 let to_sexp ast = Format.asprintf "@[%a@]@." Sexp.print (Sexp.create ast)
+
+let to_string = Html.to_plain_text

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -32,5 +32,4 @@ let to_html ?auto_identifiers doc =
   Html.to_string (Html.of_doc ?auto_identifiers doc)
 
 let to_sexp ast = Format.asprintf "@[%a@]@." Sexp.print (Sexp.create ast)
-
 let to_string = Html.to_plain_text

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -32,4 +32,4 @@ let to_html ?auto_identifiers doc =
   Html.to_string (Html.of_doc ?auto_identifiers doc)
 
 let to_sexp ast = Format.asprintf "@[%a@]@." Sexp.print (Sexp.create ast)
-let to_string = Html.to_plain_text
+let to_plain_text = Html.to_plain_text

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -31,5 +31,5 @@ val of_string : string -> doc
 val to_html : ?auto_identifiers:bool -> doc -> string
 val to_sexp : doc -> string
 
-val to_string : 'attr inline -> string
+val to_plain_text : 'attr inline -> string
 (** Returns the text contents of an inline element. *)

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -30,3 +30,5 @@ val of_channel : in_channel -> doc
 val of_string : string -> doc
 val to_html : ?auto_identifiers:bool -> doc -> string
 val to_sexp : doc -> string
+val to_string : 'attr inline -> string
+(** Returns the text contents of an inline element. *)

--- a/src/omd.mli
+++ b/src/omd.mli
@@ -30,5 +30,6 @@ val of_channel : in_channel -> doc
 val of_string : string -> doc
 val to_html : ?auto_identifiers:bool -> doc -> string
 val to_sexp : doc -> string
+
 val to_string : 'attr inline -> string
 (** Returns the text contents of an inline element. *)


### PR DESCRIPTION
Expose function allowing to turn an inline element into a string,
keeping only the text.

This is fix for issue https://github.com/ocaml/omd/issues/299
