### PR TITLE
Add canonical tags to a few types so odoc knows where to find them

### DIFF
--- a/src/ast_block.ml
+++ b/src/ast_block.ml
@@ -11,16 +11,21 @@ module InlineContent = struct
 end
 
 module List_types = struct
+
+  (** @canonical Omd.list_type *)
   type list_type =
     | Ordered of int * char
     | Bullet of char
 
+  (** @canonical Omd.list_spacing *)
   type list_spacing =
     | Loose
     | Tight
 end
 
 module Table_alignments = struct
+
+  (** @canonical Omd.cell_alignment *)
   type cell_alignment =
     | Default
     | Left

--- a/src/ast_block.ml
+++ b/src/ast_block.ml
@@ -11,7 +11,6 @@ module InlineContent = struct
 end
 
 module List_types = struct
-
   (** @canonical Omd.list_type *)
   type list_type =
     | Ordered of int * char
@@ -24,7 +23,6 @@ module List_types = struct
 end
 
 module Table_alignments = struct
-
   (** @canonical Omd.cell_alignment *)
   type cell_alignment =
     | Default

--- a/src/ast_inline.ml
+++ b/src/ast_inline.ml
@@ -5,6 +5,8 @@
         those somehow? Or should we include these in the document model, but
         but with the caveat that most renderings of the document don't support
         attributes in these nodes? *)
+
+(** @canonical Omd.inline *)
 type 'attr inline =
   | Concat of 'attr * 'attr inline list
   | Text of 'attr * string


### PR DESCRIPTION
Currently the docs are either missing tags where they contain hidden items or linking to hidden modules. See ocaml/odoc#1091