### PR TITLE
Add Footnote Support

### DIFF
--- a/src/ast_block.ml
+++ b/src/ast_block.ml
@@ -37,6 +37,8 @@ module Make (C : BlockContent) = struct
     ; defs : 'attr C.t list
     }
 
+  type 'attr footnote = { id: string; label: string; content: 'attr C.t }
+
   (* A value of type 'attr is present in all variants of this type. We use it to associate
      extra information to each node in the AST. Cn the common case, the attributes type defined
      above is used. We might eventually have an alternative function to parse blocks while keeping
@@ -51,6 +53,7 @@ module Make (C : BlockContent) = struct
     | Html_block of 'attr * string
     | Definition_list of 'attr * 'attr def_elt list
     | Table of 'attr * ('attr C.t * cell_alignment) list * 'attr C.t list list
+    | Footnote_list of 'attr footnote list
         (** A table is represented by a header row, which is a list of pairs of
             header cells and alignments, and a list of rows *)
 end
@@ -79,6 +82,10 @@ module MakeMapper (Src : BlockContent) (Dst : BlockContent) = struct
           ( attr
           , List.map (fun (header, alignment) -> (f header, alignment)) headers
           , List.map (List.map f) rows )
+    | Footnote_list footnotes ->
+        Footnote_list
+          (List.map (fun { SrcBlock.id; content; label } -> { DstBlock.id = id; content = f content; label })
+          footnotes)
 end
 
 module Mapper = MakeMapper (StringContent) (InlineContent)

--- a/src/ast_inline.ml
+++ b/src/ast_inline.ml
@@ -16,6 +16,7 @@ type 'attr inline =
   | Link of 'attr * 'attr link
   | Image of 'attr * 'attr link
   | Html of 'attr * string
+  | Sup of 'attr * 'attr inline
 
 and 'attr link =
   { label : 'attr inline

--- a/src/html.ml
+++ b/src/html.ml
@@ -169,6 +169,7 @@ let to_plain_text t =
         go i
     | Hard_break _ | Soft_break _ -> Buffer.add_char buf ' '
     | Html _ -> ()
+    | Sup (_, i) -> go i
   in
   go t;
   Buffer.contents buf
@@ -191,6 +192,9 @@ and img label destination title attrs =
   in
   elt Inline "img" attrs None
 
+and sup attrs child =
+  elt Inline "sup" attrs (Some child)
+
 and inline = function
   | Ast.Impl.Concat (_, l) -> concat_map inline l
   | Text (_, t) -> text t
@@ -204,6 +208,9 @@ and inline = function
       url label destination title attr
   | Image (attr, { label; destination; title }) ->
       img label destination title attr
+  | Sup (attrs, il) ->
+      sup attrs (inline il)
+  (* TODO: handle sup tag *)
 
 let alignment_attributes = function
   | Default -> []

--- a/src/html.ml
+++ b/src/html.ml
@@ -255,6 +255,28 @@ let table_body headers rows =
                     row)))
           rows))
 
+let footnote_block content =
+  elt Block "div" [("class", "footnotes")]
+    (Some (concat
+            (elt Inline "hr" [] None)
+            content))
+
+let footnote_list footnotes =
+  let backlink label =
+    (elt Block "a" [("href", "#fnref:" ^ label)] (Some (text "↩"))) in
+  let p footnote =
+    (elt
+      Block "p" []
+      (Some
+        (concat
+          (inline footnote.content)
+          (backlink footnote.label))))
+  in
+  elt Block "ol" []
+    (Some (concat_map
+            (fun footnote -> elt Block "li" [("id", footnote.id)] (Some (p footnote)))
+            footnotes))
+
 let rec block ~auto_identifiers = function
   | Blockquote (attr, q) ->
       elt
@@ -316,28 +338,7 @@ let rec block ~auto_identifiers = function
         "table"
         attr
         (Some (concat (table_header headers) (table_body headers rows)))
-  | Footnote_list footnotes ->
-    let footnote_block content =
-      elt Block "div" [("class", "footnotes")]
-        (Some (concat
-                (elt Inline "hr" [] None)
-                content))
-    and footnote_list footnotes =
-      let footnote_backlink label =
-        (elt Block "a" [("href", "#fnref:" ^ label)] (Some (text "↩"))) in
-      let footnote_p footnote =
-        (elt
-          Block "p" []
-          (Some
-            (concat
-              (inline footnote.content)
-              (footnote_backlink footnote.label))))
-      in
-      elt Block "ol" []
-        (Some (concat_map
-                (fun footnote -> elt Block "li" [("id", footnote.id)] (Some (footnote_p footnote))) footnotes))
-    in
-      footnote_block (footnote_list footnotes)
+  | Footnote_list footnotes -> footnote_block (footnote_list footnotes)
 
 let of_doc ?(auto_identifiers = true) doc =
   let identifiers = Identifiers.empty in

--- a/src/html.ml
+++ b/src/html.ml
@@ -263,7 +263,7 @@ let footnote_block content =
 
 let footnote_list footnotes =
   let backlink label =
-    (elt Block "a" [("href", "#fnref:" ^ label)] (Some (text "↩"))) in
+    url (Text ([], "↩")) ("#fnref:" ^ label) None [] in
   let p footnote =
     (elt
       Block "p" []

--- a/src/html.ml
+++ b/src/html.ml
@@ -338,7 +338,11 @@ let rec block ~auto_identifiers = function
         "table"
         attr
         (Some (concat (table_header headers) (table_body headers rows)))
-  | Footnote_list footnotes -> footnote_block (footnote_list footnotes)
+  | Footnote_list footnotes -> begin
+      match List.is_empty footnotes with
+      | false -> footnote_block (footnote_list footnotes)
+      | true -> Null
+    end
 
 let of_doc ?(auto_identifiers = true) doc =
   let identifiers = Identifiers.empty in

--- a/src/html.ml
+++ b/src/html.ml
@@ -113,7 +113,7 @@ module Identifiers : sig
   val empty : t
 
   val touch : string -> t -> int * t
-  (** Bump the frequency count for the given string. 
+  (** Bump the frequency count for the given string.
       It returns the previous count (before bumping) *)
 end = struct
   module SMap = Map.Make (String)
@@ -210,7 +210,6 @@ and inline = function
       img label destination title attr
   | Sup (attrs, il) ->
       sup attrs (inline il)
-  (* TODO: handle sup tag *)
 
 let alignment_attributes = function
   | Default -> []
@@ -317,6 +316,23 @@ let rec block ~auto_identifiers = function
         "table"
         attr
         (Some (concat (table_header headers) (table_body headers rows)))
+  | Footnote_list footnotes ->
+    let footnote_block content =
+      elt Block "div" [("class", "footnotes")] (Some content)
+    and footnote_list footnotes =
+      let footnote_p footnote =
+        (elt
+          Block "p" []
+          (Some
+            (concat
+              (inline footnote.content)
+              (elt Block "a" [("href", "#fnref:" ^ footnote.label)] (Some (text "↩"))))))
+      in
+      elt Block "ol" []
+        (Some (concat_map
+                (fun footnote -> elt Block "li" [("id", footnote.id)] (Some (footnote_p footnote))) footnotes))
+    in
+      footnote_block (footnote_list footnotes)
 
 let of_doc ?(auto_identifiers = true) doc =
   let identifiers = Identifiers.empty in

--- a/src/html.ml
+++ b/src/html.ml
@@ -318,15 +318,20 @@ let rec block ~auto_identifiers = function
         (Some (concat (table_header headers) (table_body headers rows)))
   | Footnote_list footnotes ->
     let footnote_block content =
-      elt Block "div" [("class", "footnotes")] (Some content)
+      elt Block "div" [("class", "footnotes")]
+        (Some (concat
+                (elt Inline "hr" [] None)
+                content))
     and footnote_list footnotes =
+      let footnote_backlink label =
+        (elt Block "a" [("href", "#fnref:" ^ label)] (Some (text "↩"))) in
       let footnote_p footnote =
         (elt
           Block "p" []
           (Some
             (concat
               (inline footnote.content)
-              (elt Block "a" [("href", "#fnref:" ^ footnote.label)] (Some (text "↩"))))))
+              (footnote_backlink footnote.label))))
       in
       elt Block "ol" []
         (Some (concat_map

--- a/src/omd.ml
+++ b/src/omd.ml
@@ -22,14 +22,6 @@ let parse_inlines (md, defs) : doc =
     in
     List.map f defs
   in
-  (* List.iter
-    (fun def -> Printf.printf
-                  "def: %s, kind=%s\n"
-                  def.Parser.label
-                  (match def.Parser.kind with
-                    | Parser.Footnote -> "Footnote"
-                    | Parser.Reference -> "Reference"))
-    defs;*)
   let footnotes = List.filter_map
     (fun def -> match def.Parser.kind with
       | Footnote { id; label; } -> Some ({ id; label; Ast_block.Raw.content = def.destination; })

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1834,7 +1834,7 @@ let rec inline defs st =
                   let label = Pre.parse_emph xs in
                   let off1 = pos st in
                   match link_label false st with
-                  | label_text, is_footnote -> (
+                  | label_text, _ -> (
                       let s = normalize label_text in
                       match
                         List.find_opt
@@ -1850,10 +1850,6 @@ let rec inline defs st =
                             match k with
                             | Img -> Image (attr, def)
                             | Url -> Link (attr, def)
-                          in
-                          let r = match is_footnote with
-                          | true -> Sup ([], r)
-                          | false -> r
                           in
                           loop ~seen_link (Pre.R r :: acc') st
                       | None ->

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -1691,6 +1691,11 @@ let rec inline defs st =
               defs
           with
           | Some { label = _; destination; title; attributes = attr } ->
+              (* If reference is footnote, we should remove '^' prefix from the text to display *)
+              let lab = match is_footnote with
+                | true -> String.sub lab 1 (String.length lab - 1)
+                | false -> lab
+              in
               let lab1 = inline defs (of_string lab) in
               let r =
                 let def = { label = lab1; destination; title } in

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -21,6 +21,7 @@ and inline = function
   | Link (_, def) -> List [ Atom "url"; link def ]
   | Html (_, s) -> List [ Atom "html"; Atom s ]
   | Image _ -> Atom "img"
+  | Sup _ -> Atom "sup"
 
 let table_header (header, alignment) =
   List

--- a/src/sexp.ml
+++ b/src/sexp.ml
@@ -61,6 +61,7 @@ let rec block = function
         ; List (List.map table_header headers)
         ; List (List.map (fun row -> List (List.map inline row)) rows)
         ]
+  | Footnote_list _footnotes -> List []
 
 let create ast = List (List.map block ast)
 

--- a/src/toc.ml
+++ b/src/toc.ml
@@ -27,7 +27,8 @@ let headers =
           | List (_, _, _, block_lists) -> List.iter loop block_lists
           | Paragraph _ | Thematic_break _ | Html_block _ | Definition_list _
           | Code_block _ | Table _ ->
-              ())
+              ()
+          | Footnote_list _ -> ())
         blocks
     in
     loop doc;

--- a/src/toc.ml
+++ b/src/toc.ml
@@ -9,6 +9,7 @@ let rec remove_links inline =
   | Image (attr, link) ->
       Image (attr, { link with label = remove_links link.label })
   | Hard_break _ | Soft_break _ | Html _ | Code _ | Text _ -> inline
+  | Sup (_, child) -> remove_links child
 
 let headers =
   let remove_links_f = remove_links in

--- a/tests/attributes.md
+++ b/tests/attributes.md
@@ -296,7 +296,7 @@ Footnotes:
 [^footnote]: link
 .
 <p><sup><a href="#fn:footnote" id="fnref:footnote">footnote</a></sup></p>
-<div class="footnotes"><ol><li id="fn:footnote"><p>link<a href="#fnref:footnote">↩</a>
+<div class="footnotes"><hr /><ol><li id="fn:footnote"><p>link<a href="#fnref:footnote">↩</a>
 </p></li>
 </ol>
 </div>

--- a/tests/attributes.md
+++ b/tests/attributes.md
@@ -295,5 +295,9 @@ Footnotes:
 
 [^footnote]: link
 .
-<p><sup><a href="link">footnote</a></sup></p>
+<p><sup><a href="#fn:footnote" id="fnref:footnote">footnote</a></sup></p>
+<div class="footnotes"><ol><li id="fn:footnote"><p>link<a href="#fnref:footnote">↩</a>
+</p></li>
+</ol>
+</div>
 ````````````````````````````````

--- a/tests/attributes.md
+++ b/tests/attributes.md
@@ -295,5 +295,5 @@ Footnotes:
 
 [^footnote]: link
 .
-<p><sup><a href="bar">footnote</a><\sup></p>
+<p><sup><a href="link">footnote</a></sup></p>
 ````````````````````````````````

--- a/tests/attributes.md
+++ b/tests/attributes.md
@@ -296,8 +296,7 @@ Footnotes:
 [^footnote]: link
 .
 <p><sup><a href="#fn:footnote" id="fnref:footnote">footnote</a></sup></p>
-<div class="footnotes"><hr /><ol><li id="fn:footnote"><p>link<a href="#fnref:footnote">↩</a>
-</p></li>
+<div class="footnotes"><hr /><ol><li id="fn:footnote"><p>link<a href="#fnref:footnote">↩</a></p></li>
 </ol>
 </div>
 ````````````````````````````````

--- a/tests/attributes.md
+++ b/tests/attributes.md
@@ -287,3 +287,13 @@ Ref id attributes testing
 <p><img src="ref_3" alt="Ref 3" id="id1" /></p>
 <p><img src="ref_4" alt="Ref 4" id="id2b" /></p>
 ````````````````````````````````
+
+Footnotes:
+
+```````````````````````````````` example
+[^footnote]
+
+[^footnote]: link
+.
+<p><sup><a href="bar">footnote</a><\sup></p>
+````````````````````````````````

--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -688,6 +688,7 @@
   attributes-013.md attributes-013.html
   attributes-014.md attributes-014.html
   attributes-015.md attributes-015.html
+  attributes-016.md attributes-016.html
   def_list-001.md def_list-001.html)
  (action (run ./extract_tests.exe -generate-test-files %{deps})))
 (rule
@@ -4849,6 +4850,13 @@
  (action (diff attributes-015.html attributes-015.html.new)))
 (rule
  (action
+  (with-stdout-to attributes-016.html.new
+   (run ./omd.exe %{dep:attributes-016.md}))))
+(rule
+ (alias attributes-016)
+ (action (diff attributes-016.html attributes-016.html.new)))
+(rule
+ (action
   (with-stdout-to def_list-001.html.new
    (run ./omd.exe %{dep:def_list-001.md}))))
 (rule
@@ -5544,4 +5552,5 @@
   (alias attributes-013)
   (alias attributes-014)
   (alias attributes-015)
+  (alias attributes-016)
   (alias def_list-001)))


### PR DESCRIPTION
I use omd for my personal static site generator and I am very happy with it (thank you very much!). I wanted to use footnotes so I created this PR. It's my first time working on this project, so I would welcome any feedback.

Footnote support is based on https://www.markdownguide.org/extended-syntax/#footnotes. As far as I see CommonMark doesn't specify footnotes.

## Screenshots
Example screenshots for the feature from my page
![Screenshot from 2024-10-09 11-42-03](https://github.com/user-attachments/assets/c44936a7-1ac0-4cb8-be3c-b895027f2f01)
![Screenshot from 2024-10-09 11-42-21](https://github.com/user-attachments/assets/cc9df1dc-b79d-4d0e-95c2-0802d169c67e)

